### PR TITLE
Read alarm's description from alarm API instead of alarm-definition API

### DIFF
--- a/plugins/monitoring/app/models/monitoring/alarm.rb
+++ b/plugins/monitoring/app/models/monitoring/alarm.rb
@@ -33,6 +33,10 @@ module Monitoring
       read(:alarm_definition)["name"] || nil
     end
 
+    def alarm_description
+      read(:alarm_definition)["description"] || nil
+    end
+
     def used_metrics
       metrics = read(:metrics) || nil
       return nil unless metrics

--- a/plugins/monitoring/app/views/monitoring/alarms/_list_row.html.haml
+++ b/plugins/monitoring/app/views/monitoring/alarms/_list_row.html.haml
@@ -1,9 +1,8 @@
-- definition = @alarm_definitions[alarm.alarm_definition_id]
 %tr
   %td= show_state(alarm.state)
   %td= show_severity(alarm.severity)
-  %td= highlight(definition.name,@search)
-  %td= highlight(definition.description,@search)
+  %td= highlight(alarm.alarm_definition_name,@search)
+  %td= highlight(alarm.alarm_description,@search)
   %td= alarm.state_updated_timestamp
   %th.snug
     .btn-group
@@ -11,8 +10,8 @@
         %span.fa.fa-cog
 
       %ul.dropdown-menu.dropdown-menu-right{ role: 'menu' } 
-        %li= link_to 'Details', plugin('monitoring').alarm_path(alarm.id, name: definition.name) , data: { modal: true }
-        %li= link_to 'History', plugin('monitoring').alarm_history_path(alarm.id, name: definition.name), data: { modal: true }
+        %li= link_to 'Details', plugin('monitoring').alarm_path(alarm.id, name: alarm.alarm_definition_name) , data: { modal: true }
+        %li= link_to 'History', plugin('monitoring').alarm_history_path(alarm.id, name: alarm.alarm_definition_name), data: { modal: true }
         %li= link_to 'Definition', plugin('monitoring').alarm_definition_path(alarm.alarm_definition_id) , data: { modal: true }
         - if current_user.is_allowed?("monitoring:monitoring:alarm_delete")
           %li= link_to 'Delete', plugin('monitoring').alarm_path(alarm.id), method: :delete, data: { confirm: "Are you sure?" }


### PR DESCRIPTION
 This allows us to show the alarm's description with template variables filled in by Monasca, and potentially avoids a call to the alarm-definition API.