### PR TITLE
[networking] add pagination to networks

### DIFF
--- a/plugins/networking/app/views/networking/networks/index.html.haml
+++ b/plugins/networking/app/views/networking/networks/index.html.haml
@@ -23,5 +23,7 @@
       - else
         - @networks.each do | network |
           = render partial: 'item', locals: {network: network}
+
+  = render_paginatable(@networks)
 - else
   = render "application/projects_list"


### PR DESCRIPTION
the list for the cloud_network_admin is getting too long, so paginate

needs activated pagination in neutron, see https://github.com/sapcc/openstack-helm/commit/f3c49865c8c59e0431b499228ea2db4cbeb0236b