### PR TITLE
[identity] add translation to role names

### DIFF
--- a/plugins/identity/app/helpers/identity/projects_helper.rb
+++ b/plugins/identity/app/helpers/identity/projects_helper.rb
@@ -18,5 +18,9 @@ module Identity
 
     end
 
+    def role_label_long(role_name)
+      t("roles.#{role_name}") + " (#{role_name})"
+    end
+
   end
 end

--- a/plugins/identity/app/views/identity/projects/groups/_group.html.haml
+++ b/plugins/identity/app/views/identity/projects/groups/_group.html.haml
@@ -1,6 +1,6 @@
 %tr.table{class: "#{'danger' if local_assigns.has_key?(:new_group)}"}
   %td.snug
     = link_to group_name, projects_group_members_path(group_id: group_id), data: {modal: true}
-  %td{data: {roles_display: true, roles_current: group_roles.collect{|r| r[:name]} }}
+  %td{data: {roles_display: true, roles_current: group_roles.collect{|r| role_label_long(r[:name])} }}
   %td.snug
-    = select_tag("role_assignments[#{group_id}]",options_for_select(roles.collect{|r| [r.name, r.id] }, group_roles.collect{|r| r[:id]}), {multiple: true, data: {roles_select: true}, disabled: !can_update})
+    = select_tag("role_assignments[#{group_id}]",options_for_select(roles.collect{|r| [role_label_long(r.name), r.id] }, group_roles.collect{|r| r[:id]}), {multiple: true, data: {roles_select: true}, disabled: !can_update})

--- a/plugins/identity/app/views/identity/projects/members/_member.html.haml
+++ b/plugins/identity/app/views/identity/projects/members/_member.html.haml
@@ -9,6 +9,6 @@
     %br
     = user_description
 
-  %td{data: {roles_display: true, roles_current: user_roles.collect{|r| r[:name]} }}
+  %td{data: {roles_display: true, roles_current: user_roles.collect{|r| role_label_long(r[:name])} }}
   %td.snug
-    = select_tag("role_assignments[#{user_id}]",options_for_select(roles.collect{|r| [r.name, r.id] }, user_roles.collect{|r| r[:id]}), {multiple: true, data: {roles_select: true}, disabled: !can_update})
+    = select_tag("role_assignments[#{user_id}]",options_for_select(roles.collect{|r| [role_label_long(r.name), r.id] }, user_roles.collect{|r| r[:id]}), {multiple: true, data: {roles_select: true}, disabled: !can_update})

--- a/plugins/identity/config/locales/en.yml
+++ b/plugins/identity/config/locales/en.yml
@@ -6,3 +6,23 @@ en:
     ssh-key:
       name: Name
       public_key: Public Key
+  roles:
+      admin: Keystone Administrator
+      member: Member
+      service: Service User
+      swiftoperator: Object Store Administrator
+      swiftreseller: Object Store Cloud Administrator
+      dns_admin: Designate Administrator
+      cloud_dns_admin: Designate Cloud Administrator
+      monasca-agent: Monitoring Agent
+      monasca-user: Monitoring User
+      monasca-viewer: Monitoring Read-Only
+      monitoring-delegate: Monitoring Delegate
+      cloud_image_admin: Glance Cloud Administrator
+      network_admin: Neutron Administrator
+      cloud_network_admin: Neutron Cloud Administrator
+      compute_viewer: Nova Read-Only
+      compute_admin: Nova Administrator
+      cloud_compute_admin: Nova Cloud Administrator
+      cfm_user: Cloud Frame User
+      cfm_admin: Cloud Frame Administrator


### PR DESCRIPTION
for more clarity we label the role names. most important for role `admin` to be identified as 'Keystone Admininistrator'

Happy Fighting over the label names 😄 💥 

@edda: okay? 

@urfuwo FYI

![image](https://cloud.githubusercontent.com/assets/8159679/21524397/074f5042-cd16-11e6-9f23-7f38c1ad3f58.png)
