### PR TITLE
textual change. in case no floating IPs available.

### DIFF
--- a/plugins/compute/app/views/compute/instances/new_floatingip.html.haml
+++ b/plugins/compute/app/views/compute/instances/new_floatingip.html.haml
@@ -24,7 +24,7 @@
 
 - else
   %div{class: modal? ? 'modal-body' : ''}
-    %p There is no floating IP available. Please allocate a new IP.
+    %p There is no floating IP available. Allocate a new IP. Please also note, that it'll not get attached automatically.
     = link_to 'Allocate IP', plugin('networking').new_floating_ip_path, data: {modal: true}
 
   %div.buttons{class: modal? ? 'modal-footer' : ''}

--- a/plugins/loadbalancing/app/views/loadbalancing/loadbalancers/new_floatingip.html.haml
+++ b/plugins/loadbalancing/app/views/loadbalancing/loadbalancers/new_floatingip.html.haml
@@ -23,7 +23,7 @@
     
 - else
   %div{class: modal? ? 'modal-body' : ''}
-    %p There is no floating IP available. Please allocate a new IP. 
+    %p There is no floating IP available. Allocate a new IP. Please also note, that it'll not get attached automatically. 
     = link_to 'Allocate IP', plugin('networking').new_floating_ip_path, data: {modal: true}      
 
   %div.buttons{class: modal? ? 'modal-footer' : ''}


### PR DESCRIPTION
Users are presented a dialog to create a floating ips, when floating IPs exhausted in the project. 
When a user does that, the IP is not assigned. Quite miss-leading when using it.