### PR TITLE
remove unused extra policy_default_param

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -1,13 +1,8 @@
 module Compute
   class InstancesController < Compute::ApplicationController
-    before_filter do 
-      @policy_default_params ||= {}
-      @policy_default_params[:project] = @active_project
-    end
-    
     authorization_context 'compute'
     authorization_required
-    
+
     def index
       @instances = []
       if @scoped_project_id


### PR DESCRIPTION
I could create an instance without these lines and without having a special nova role

@andypf please have a look