### PR TITLE
[compute] compute_cloud_admin can view all instances

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,15 +1,15 @@
 module ApplicationHelper
   def render_paginatable(items)
-    return if !items or items.length==0
-    if @pagination_enabled
-      content_tag(:div, class: 'pagination') do
-        concat(content_tag(:span, "#{@pagination_seen_items+1} - #{@pagination_seen_items+items.length} ", class: 'current-window'))
-        if @pagination_current_page>1
-          concat(link_to 'Previous Page', page: @pagination_current_page-1, marker: items.first.id, reverse: true)
+    return if !@pagination_enabled || !items || items.length.zero?
+    content_tag(:div, class: 'pagination') do
+      if @pagination_current_page > 1 || @pagination_has_next
+        concat(content_tag(:span, "#{@pagination_seen_items + 1} - #{@pagination_seen_items + items.length} ", class: 'current-window'))
+        if @pagination_current_page > 1
+          concat(link_to('Previous Page', page: @pagination_current_page - 1, marker: items.first.id, reverse: true))
         end
         if @pagination_has_next
-          concat(" | ")
-          concat(link_to 'Next Page', page: @pagination_current_page+1, marker: items.last.id)
+          concat(' | ')
+          concat(link_to('Next Page', page: @pagination_current_page + 1, marker: items.last.id))
         end
       end
     end

--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -12,22 +12,16 @@ module Compute
           services.compute.servers(@admin_option.merge(pagination_options))
         end
 
-        # get/calculate quota data
-        cores = 0
-        ram = 0
-        @instances.each do |i|
-          flavor = i.flavor_object
-          if flavor
-            cores += flavor.vcpus.to_i
-            ram += flavor.ram.to_i
-          end
-        end
+        # get/calculate quota data for non-admin view
+        unless @all_projects
+          usage = services.compute.usage
 
-        @quota_data = services.resource_management.quota_data([
-          {service_name: :compute, resource_name: :instances, usage: @instances.length},
-          {service_name: :compute, resource_name: :cores, usage: cores},
-          {service_name: :compute, resource_name: :ram, usage: ram}
-        ])
+          @quota_data = services.resource_management.quota_data([
+            {service_name: :compute, resource_name: :instances, usage: usage.instances},
+            {service_name: :compute, resource_name: :cores, usage: usage.cores},
+            {service_name: :compute, resource_name: :ram, usage: usage.ram}
+          ])
+        end
       end
     end
 

--- a/plugins/compute/app/models/compute/usage.rb
+++ b/plugins/compute/app/models/compute/usage.rb
@@ -1,0 +1,15 @@
+module Compute
+  class Usage < Core::ServiceLayer::Model
+    def cores
+      read('totalCoresUsed')
+    end
+
+    def instances
+      read('totalInstancesUsed')
+    end
+
+    def ram
+      read('totalRAMUsed')
+    end
+  end
+end

--- a/plugins/compute/app/services/service_layer/compute_service.rb
+++ b/plugins/compute/app/services/service_layer/compute_service.rb
@@ -36,6 +36,10 @@ module ServiceLayer
       driver.map_to(Compute::Server).servers(filter)
     end
 
+    def usage(filter = {})
+      driver.map_to(Compute::Usage).usage(filter)
+    end
+
     ##################### HYPERVISORS #########################
 
     def hypervisors(filter = {})

--- a/plugins/compute/app/views/compute/instances/_item.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item.html.haml
@@ -9,6 +9,9 @@
       = link_to instance.name, plugin('compute').instance_path(id: instance.id), data: {modal: true}
     - else
       = instance.name
+  - if @all_projects
+    %td
+      - project_id_and_name(instance.tenant_id)
   %td= instance.availability_zone
   %td.snug-nowrap
     - instance.addresses.each do |network_name, ip_values|

--- a/plugins/compute/app/views/compute/instances/index.html.haml
+++ b/plugins/compute/app/views/compute/instances/index.html.haml
@@ -9,9 +9,11 @@
     %thead
       %tr
         %th Name
+        - if @all_projects
+          %th Owning Project
         %th
           AZ
-          %i.fa.fa-fw.fa-info-circle{data: { toggle: "tooltip", placement: "top", title: "Availability Zone"}}         
+          %i.fa.fa-fw.fa-info-circle{data: { toggle: "tooltip", placement: "top", title: "Availability Zone"}}
         %th IPs
         %th OS
         %th Size
@@ -25,5 +27,7 @@
       - else
         - @instances.each do | instance |
           = render partial: 'item', locals: {instance: instance}
+
+  = render_paginatable(@instances)
 - else
   = render "application/projects_list"

--- a/plugins/compute/config/policy.json
+++ b/plugins/compute/config/policy.json
@@ -6,6 +6,7 @@
   "context_is_editor": "rule:context_is_admin or rule:member",
   "context_is_viewer":  "rule:context_is_editor or rule:viewer",
 
+  "compute:all_projects": "rule:context_is_admin",
   "compute:instance_get": "rule:context_is_viewer",
   "compute:instance_list": "rule:context_is_viewer",
   "compute:instance_create": "rule:context_is_editor and (not rule:monsoon2_domain or rule:project_parent)",

--- a/plugins/compute/lib/compute/driver/fog.rb
+++ b/plugins/compute/lib/compute/driver/fog.rb
@@ -110,6 +110,10 @@ module Compute
         handle_response{@fog.remove_fixed_ip(server_id, address)}
       end
 
+      def usage(filter = {})
+        handle_response { @fog.get_limits(filter).body['limits']['absolute'] }
+      end
+
       ############################# HYPERVISORS ##############################
 
       def hypervisors(filter = {})


### PR DESCRIPTION
added pagination + owning project

@edda / @andypf : ok with you?

would it be good to be able to turn this on/off as cloud_compute_admin or adding a flag/warning that such view is not limited to the project I am currently scoped to? same question applies to existing (for zones, flavors, images, networks ...) and coming super admin views