### PR TITLE
make domain quotas binding

### DIFF
--- a/plugins/resource_management/app/views/resource_management/domain_admin/review_package_request.html.haml
+++ b/plugins/resource_management/app/views/resource_management/domain_admin/review_package_request.html.haml
@@ -30,7 +30,7 @@
             - data = @stats[res.service.name][res.name]
             - dt = res.data_type
             - domain_quota = data[:domain_approved_quota]
-            - new_total_quota = data[:total_current_quota] - data[:project_current_quota] + res.value_for_package(@package)
+            - new_total_quota = data[:new_total_current_quota]
             %tr{ class: new_total_quota > domain_quota ? 'bg-danger' : (new_total_quota > 0.8 * domain_quota ? 'bg-warning' : '') }
               %td
                 = t("resource_management.#{res.service.name}")
@@ -43,6 +43,13 @@
                 = dt.format(new_total_quota)
               %td= dt.format(data[:total_usage])
 
+    - unless @can_approve
+      %p.text-danger
+        You cannot approve this request because it would exceed your approved domain quota (see resources marked red).
+
   .buttons{class: modal? ? 'modal-footer' : ''}
-    %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Cancel"}} Cancel
-    %button.btn.btn-primary{type:'submit', data:{disable_with: "Please wait..."}} Approve
+    - if @can_approve
+      %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Cancel"}} Cancel
+      %button.btn.btn-primary{type:'submit', data:{disable_with: "Please wait..."}} Approve
+    - else
+      %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Close"}} Close

--- a/plugins/resource_management/app/views/resource_management/domain_admin/review_request.html.haml
+++ b/plugins/resource_management/app/views/resource_management/domain_admin/review_request.html.haml
@@ -22,6 +22,12 @@
       .col-md-2.quota-label.text-muted Preview
       .col-md-9= render partial: 'bar', locals: { data: @domain_status_new, render_quota: true }
 
+    - if @desired_quota > @maximum_quota
+      %p.text-danger{style:"margin-top:1rem"}
+        This request would exceed your domain quota. You can only approve a project quota of
+        %strong= @project_resource.data_type.format(@maximum_quota)
+        or less.
+
     %fieldset
       - previous_value = params[:resource] ? params[:resource][:approved_quota] : nil
       - if @project_resource.data_type.to_sym == :number


### PR DESCRIPTION
Whenever a domain admin adjusts project quotas, ensure that they cannot exceed their domain quota allocation.