### PR TITLE
[dns] add dns_viewer and make policy more readable

### DIFF
--- a/plugins/dns_service/config/policy.json
+++ b/plugins/dns_service/config/policy.json
@@ -1,25 +1,27 @@
 {
   "context_is_cloud_dns_admin": "role:cloud_dns_admin",
-  "context_is_dns_admin": "role:dns_admin",
-  "dns_admin": "rule:context_is_cloud_dns_admin or is_admin:True",
-  "dns_admin_or_zone_owner": "rule:dns_admin or project_id:%(zone.project_id)s",
-  "cloud_dns_admin_or_dns_admin": "rule: context_is_cloud_dns_admin or rule:context_is_dns_admin",
-  "zone_primary_or_admin": "(%(zone.type)s=='PRIMARY' and rule:admin_or_owner) or (%(zone.type)s=='SECONDARY' and is_admin:True)",
+  "member": "role:member or role:Member",
+  "dns_viewer": "role:dns_viewer",
+  "dns_admin": "role:dns_admin",
+  "context_is_dns_admin": "rule:context_is_cloud_dns_admin or rule:dns_admin",
+  "context_is_dns_editor": "rule:context_is_dns_admin or rule:member",
+  "context_is_dns_viewer":  "rule:context_is_dns_editor or rule:dns_viewer",
+  "zone_primary_or_admin": "(%(zone.type)s=='PRIMARY' and rule:context_is_dns_editor) or (%(zone.type)s=='SECONDARY' and is_admin:True)",
 
-  "dns_service:all_projects": "rule:dns_admin",
-  "dns_service:zone_list": "rule:dns_admin_or_zone_owner",
-  "dns_service:zone_get": "rule:dns_admin_or_zone_owner",
-  "dns_service:zone_create": "rule:cloud_dns_admin_or_dns_admin",
-  "dns_service:zone_update": "rule:cloud_dns_admin_or_dns_admin",
-  "dns_service:zone_delete": "rule:cloud_dns_admin_or_dns_admin",
-  "dns_service:recordset_list": "rule:dns_admin_or_zone_owner",
-  "dns_service:recordset_get": "rule:dns_admin_or_zone_owner",
+  "dns_service:all_projects": "rule:context_is_cloud_dns_admin",
+  "dns_service:zone_list": "rule:context_is_dns_viewer",
+  "dns_service:zone_get": "rule:context_is_dns_viewer",
+  "dns_service:zone_create": "rule:context_is_dns_admin",
+  "dns_service:zone_update": "rule:context_is_dns_admin",
+  "dns_service:zone_delete": "rule:context_is_dns_admin",
+  "dns_service:recordset_list": "rule:context_is_dns_viewer",
+  "dns_service:recordset_get": "rule:context_is_dns_viewer",
   "dns_service:recordset_create": "rule:zone_primary_or_admin",
   "dns_service:recordset_update": "rule:zone_primary_or_admin",
   "dns_service:recordset_delete": "rule:zone_primary_or_admin",
 
   "dns_service:pool_list": "rule:context_is_cloud_dns_admin",
 
-  "dns_service:transfer_request_create": "rule:cloud_dns_admin_or_dns_admin and project_id:%(zone.project_id)s",
-  "dns_service:transfer_request_accept": "rule:dns_admin_or_zone_owner or project_id:%(request.project_id)s or %(request.project_id)s==nil"
+  "dns_service:transfer_request_create": "rule:context_is_dns_admin and project_id:%(zone.project_id)s",
+  "dns_service:transfer_request_accept": "rule:context_is_dns_editor or project_id:%(request.project_id)s or %(request.project_id)s==nil"
 }

--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -2,6 +2,7 @@ ALLOWED_ROLES = %w(
   admin
   compute_admin
   compute_viewer
+  dns_viewer
   member
   monasca-agent
   monasca-user


### PR DESCRIPTION
reflect https://github.com/sapcc/openstack-helm/commit/f242605e111ec66aff1b4e2cc9132d19991d719d

better merge after the policy in designate backend has been rolled out, to not get confused over not working read-only