### PR TITLE
[compute] add instance action tab to show for admins

### DIFF
--- a/app/assets/stylesheets/_monsoon_theme.scss
+++ b/app/assets/stylesheets/_monsoon_theme.scss
@@ -140,6 +140,12 @@ ul {
     padding-left: 0;
     list-style-type: none;
     margin-bottom: $line-height-computed;
+
+    &.plain-list-widespaced {
+      li {
+        padding-bottom: 8px;
+      }
+    }
   }
 }
 

--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -468,8 +468,11 @@ module Compute
         end
       end
 
-      render template: 'compute/instances/update_item.js' if with_rendering
-      #redirect_to instances_url
+      if request.xhr?
+        render template: 'compute/instances/update_item.js' if with_rendering
+      else
+        redirect_to instances_url
+      end
     end
 
     def target_state_for_action(action)

--- a/plugins/compute/app/views/compute/instances/show.html.haml
+++ b/plugins/compute/app/views/compute/instances/show.html.haml
@@ -133,8 +133,9 @@
 
     - if current_user.is_allowed?("compute:all_projects")
       .tab-pane{role: 'tabpanel', id: 'actions'}
-        %ul
-          %li= link_to 'Terminate', plugin('compute').instance_path(id: @instance.id), method: :delete, data: { confirm: 'Are you sure you want to terminate this instance?', ok: 'Yes, terminate it', confirmed: :loading_status}
+        %ul.plain-list.plain-list-widespaced
+          %li= link_to 'Terminate', plugin('compute').instance_path(id: @instance.id), class: 'btn btn-danger', method: :delete, data: { confirm: 'Are you sure you want to terminate this instance?', ok: 'Yes, terminate it', confirmed: :loading_status}
+
 
 - if modal?
   .modal-footer

--- a/plugins/compute/app/views/compute/instances/show.html.haml
+++ b/plugins/compute/app/views/compute/instances/show.html.haml
@@ -9,7 +9,9 @@
     %li{role: "presentation"}= link_to 'Security Groups', '#sec_groups', aria: {controls:"security_groups"}, role: "tab", data: {toggle:"tab"}
     %li{role: "presentation"}= link_to 'Key Pairs', '#keypairs', aria: {controls:"keypairs"}, role: "tab", data: {toggle:"tab"}
     %li{role: "presentation"}= link_to 'Metadata', '#metadata', aria: {controls:"metadata"}, role: "tab", data: {toggle:"tab"}
-    %li{role: "presentation"}= link_to 'Volumes Attached ', '#volumes', aria: {controls:"volumes"}, role: "tab", data: {toggle:"tab"}
+    %li{role: "presentation"}= link_to 'Volumes Attached', '#volumes', aria: {controls:"volumes"}, role: "tab", data: {toggle:"tab"}
+    - if current_user.is_allowed?("compute:all_projects")
+      %li{ role: 'presentation' }= link_to 'Actions', '#actions', aria: { controls: 'actions' }, role: 'tab', data: { toggle: 'tab' }
 
   .tab-content
     .tab-pane.active{role:"tabpanel", id:"information"}
@@ -128,6 +130,11 @@
               %tr
                 %td= vol.displayName || vol.name
                 %td= vol.attachments.first['device']
+
+    - if current_user.is_allowed?("compute:all_projects")
+      .tab-pane{role: 'tabpanel', id: 'actions'}
+        %ul
+          %li= link_to 'Terminate', plugin('compute').instance_path(id: @instance.id), method: :delete, data: { confirm: 'Are you sure you want to terminate this instance?', ok: 'Yes, terminate it', confirmed: :loading_status}
 
 - if modal?
   .modal-footer


### PR DESCRIPTION
admins get here from looking up directly, so can't trigger actions
at the list

e.g. to delete stuck instances found via object lookup server

@edda : what do you think? is this pretty enough?