### PR TITLE
Add Maia's monitoring_viewer role

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -4,6 +4,7 @@ ALLOWED_ROLES = %w(
   compute_viewer
   dns_viewer
   member
+  monitoring_viewer
   network_admin
   network_viewer
   sharedfilesystem_admin


### PR DESCRIPTION
which is end-user assignable (permission to see tenant-metrics we have chosen to make available)