### PR TITLE
fix metric collection

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,23 +42,9 @@ module MonsoonDashboard
     plugin_mount_points = {}
     Core::PluginsManager.available_plugins.each{|plugin| plugin_mount_points[plugin.mount_point] = plugin.mount_point}
 
-    label_builder = proc do |env, code|
-      controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
-      {
-        code: code,
-        method: env['REQUEST_METHOD'].downcase,
-        host:   env['HTTP_HOST'].to_s,
-        # just take the first component of the path as a label
-        path:   env['REQUEST_PATH'][0, env['REQUEST_PATH'].index('/',1) || 20 ],
-        controller: controller_name,
-        action: env.fetch("action_dispatch.request.path_parameters",{}).fetch(:action,''),
-        plugin: controller_name[%r{^([^/]+)/},1]
-      }
-    end
-
     config.middleware.insert_after(ActionDispatch::DebugExceptions, Prometheus::Middleware::Collector, {
       counter_label_builder: proc do |env, code|
-      controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
+        controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
         {
           code: code,
           method: env['REQUEST_METHOD'].downcase,

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,23 +42,42 @@ module MonsoonDashboard
     plugin_mount_points = {}
     Core::PluginsManager.available_plugins.each{|plugin| plugin_mount_points[plugin.mount_point] = plugin.mount_point}
 
-    config.middleware.insert_after ActionDispatch::DebugExceptions, Prometheus::Middleware::Collector do |env|
+    label_builder = proc do |env, code|
+      controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
       {
+        code: code,
         method: env['REQUEST_METHOD'].downcase,
         host:   env['HTTP_HOST'].to_s,
         # just take the first component of the path as a label
         path:   env['REQUEST_PATH'][0, env['REQUEST_PATH'].index('/',1) || 20 ],
-        controller: env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller,''),
+        controller: controller_name,
         action: env.fetch("action_dispatch.request.path_parameters",{}).fetch(:action,''),
-        plugin: if env.fetch("action_dispatch.request.path_parameters",{}).fetch(:project_id,false)
-          plugin_mount_points[env['REQUEST_PATH'].split("/")[3]] || ""
-        elsif env.fetch("action_dispatch.request.path_parameters",{}).fetch(:domain_id, false)
-          plugin_mount_points[env['REQUEST_PATH'].split("/")[2]] || ""
-        else
-          ''
-        end
+        plugin: controller_name[%r{^([^/]+)/},1]
       }
     end
+
+    config.middleware.insert_after(ActionDispatch::DebugExceptions, Prometheus::Middleware::Collector, {
+      counter_label_builder: proc do |env, code|
+      controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
+        {
+          code: code,
+          method: env['REQUEST_METHOD'].downcase,
+          host:   env['HTTP_HOST'].to_s,
+          # just take the first component of the path as a label
+          path:   env['REQUEST_PATH'][0, env['REQUEST_PATH'].index('/',1) || 20 ],
+          controller: controller_name,
+          action: env.fetch("action_dispatch.request.path_parameters",{}).fetch(:action,''),
+          plugin: controller_name[%r{^([^/]+)/},1]
+        }
+      end,
+      duration_label_builder: proc do |env, code|
+        controller_name = env.fetch("action_dispatch.request.path_parameters",{}).fetch(:controller, '')
+        {
+          method: env['REQUEST_METHOD'].downcase,
+          plugin: controller_name[%r{^([^/]+)/},1],
+        }
+      end
+    })
 
     require 'prometheus/middleware/exporter'
     config.middleware.insert_after  Prometheus::Middleware::Collector, Prometheus::Middleware::Exporter


### PR DESCRIPTION
The latest ruby prometheus client needs the label builder defined slightly different.

Also the latency metric is now a histogram instead of a summary. The prometheus graphs need to be changed to work again. Somebody needs to take care of this after merging this PR.

Also I reduced the label cardianlity on the latency metrics, now we only record the request method and the plugin.