### PR TITLE
(snapshots) refine notification. just windows not working.

### DIFF
--- a/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
+++ b/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
@@ -6,7 +6,7 @@
   %div{class: modal? ? 'modal-body' : ''}
     .alert.alert-info
       %strong Please note:
-      Creating snapshots from windows images is not yet working. We are working on it!
+      Creating snapshots from windows vms is not yet working. We are working on it!
 
     = f.input :name, icon_hint: 'A snapshot is an image which preserves the disk state of a running instance.'
 

--- a/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
+++ b/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
@@ -6,7 +6,7 @@
   %div{class: modal? ? 'modal-body' : ''}
     .alert.alert-info
       %strong Please note:
-      Creating snapshots from images larger than 10-20GB is currently unreliable and likely to fail. We are working on it!
+      Creating snapshots from windows images is not yet working. We are working on it!
 
     = f.input :name, icon_hint: 'A snapshot is an image which preserves the disk state of a running instance.'
 


### PR DESCRIPTION
@edda we have all linux vms snapshots working, hence refinement of the alert info.