### PR TITLE
DHCP agent mgmt

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GIT
 
 GIT
   remote: https://github.com/sapcc/misty.git
-  revision: dd9e7f2b5b957cffd60c273668a53a3f6177557b
+  revision: b26e3fe45078e018aef927df695c81c68a4203ca
   branch: master
   specs:
     misty (1.2.0)
@@ -640,4 +640,4 @@ DEPENDENCIES
   webpacker (~> 3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -6,7 +6,7 @@ module ViewHelper
       'Project', @scoped_domain_id, id
     )
     # project not found in friendly ids -> load from api
-    remote_project ||= service_user.identity.find_project_by_name_or_id(
+    remote_project ||= cloud_admin.identity.find_project_by_name_or_id(
       @scoped_domain_id, id
     )
     remote_project ||= services_ng.identity.find_project(id)
@@ -22,7 +22,7 @@ module ViewHelper
         'Project', @scoped_domain_id, project
       )
       # project not found in friendly ids -> load from api
-      remote_project ||= service_user.identity.find_project_by_name_or_id(
+      remote_project ||= cloud_admin.identity.find_project_by_name_or_id(
         @scoped_domain_id, project
       )
       remote_project ||= services_ng.identity.find_project(project)

--- a/plugins/networking/app/assets/javascripts/networking/plugin/dhcp_agents.js.coffee
+++ b/plugins/networking/app/assets/javascripts/networking/plugin/dhcp_agents.js.coffee
@@ -1,0 +1,29 @@
+$.fn.dhcpFormControl = (options={}) ->
+
+  this.each () ->
+    # get form control button
+    $control  = $(this)
+    # get form
+    $form = $($control.data('controlDhcpForm'))
+    # setup form
+    $form.css( "display", "none").removeClass('hidden')
+
+    if typeof options is 'string'
+      if options=='hide'
+        $(this).text('+').addClass('btn-primary').removeClass('btn-default')
+        $form.hide('slow')
+      else if options=='show'
+        $form.show('slow')
+        $(this).text('cancel').removeClass('btn-primary').addClass('btn-default')
+      return this;
+
+    # setup control behavior
+    $control.click () ->
+      if $form.is(':visible')
+        $(this).text('+').addClass('btn-primary').removeClass('btn-default')
+        $form.hide('slow')
+      else
+        $form.show('slow')
+        $(this).text('cancel').removeClass('btn-primary').addClass('btn-default')
+
+    return this

--- a/plugins/networking/app/controllers/networking/networks/dhcp_agents_controller.rb
+++ b/plugins/networking/app/controllers/networking/networks/dhcp_agents_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Networking
+  # Implements Network Rbac actions
+  class Networks::DhcpAgentsController < NetworksController
+    def index
+      @dhcp_agents = services_ng.networking.network_dhcp_agents(@network_id)
+      @new_dhcp_agents = services_ng.networking.dhcp_agents.delete_if{ |existing_agent| @dhcp_agents.map(&:id).include?(existing_agent.id) }
+    end
+
+    def create
+      @dhcp_agent = services_ng.networking.new_dhcp_agent(params[:dhcp])
+      @dhcp_agent.network_id = @network_id
+      @dhcp_agent.save
+    end
+
+    def destroy
+      @dhcp_agent = services_ng.networking.new_dhcp_agent
+      @dhcp_agent.id = params[:id]
+      @dhcp_agent.network_id = @network_id
+
+      if @dhcp_agent.destroy
+        flash.now[:notice] = 'DHCP Agent successfully removed.'
+      else
+        flash.now[:error] = @dhcp_agent.errors.full_messages.to_sentence
+      end
+
+      respond_to do |format|
+        format.js {}
+        format.html do
+          redirect_to plugin('networking').send(
+            "networks_#{@network_type}_dhcp_agents_path"
+          )
+        end
+      end
+    end
+
+    private
+
+    def load_type
+      @network_type = params.key?('private_id') ? 'private' : 'external'
+      @network_id   = params["#{@network_type}_id"]
+    end
+  end
+end

--- a/plugins/networking/app/models/networking/dhcp_agent.rb
+++ b/plugins/networking/app/models/networking/dhcp_agent.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Networking
+  # Implements Openstack DHCP Agent
+  class DhcpAgent < Core::ServiceLayerNg::Model
+    def status
+      alive == true ? 'alive' : 'dead'
+    end
+
+    def admin_state
+      admin_state_up ? 'UP' : 'DOWN'
+    end
+
+    def destroy
+      before_destroy
+      rescue_api_errors do
+        @service.delete_dhcp_agent(id, network_id)
+      end
+    end
+  end
+end

--- a/plugins/networking/app/services/service_layer_ng/networking_service.rb
+++ b/plugins/networking/app/services/service_layer_ng/networking_service.rb
@@ -12,6 +12,7 @@ module ServiceLayerNg
     include NetworkingServices::Router
     include NetworkingServices::Rbac
     include NetworkingServices::Quota
+    include NetworkingServices::DhcpAgent
 
     def available?(_action_name_sym = nil)
       api.catalog_include_service?('network', region)

--- a/plugins/networking/app/services/service_layer_ng/networking_services/dhcp_agent.rb
+++ b/plugins/networking/app/services/service_layer_ng/networking_services/dhcp_agent.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ServiceLayerNg
+  module NetworkingServices
+    # Implements Openstack DHCP Agents
+    module DhcpAgent
+      def dhcp_agents
+        api.networking.list_agents(agent_type: 'DHCP agent')
+           .map_to(Networking::DhcpAgent)
+      end
+
+      def network_dhcp_agents(network_id)
+        api.networking.list_network_dhcp_agents(network_id)
+           .map_to(Networking::DhcpAgent)
+      end
+
+      def new_dhcp_agent(attributes = {})
+        map_to(Networking::DhcpAgent, attributes)
+      end
+
+      def delete_dhcp_agent(agent_id, network_id)
+        api.networking.delete_agent_dhcp_network(agent_id, network_id)
+      end
+
+      def create_dhcp_agent(attributes)
+        create_attributes = attributes.deep_dup
+        agent_id = create_attributes.delete(:agent_id)
+        begin
+          api.networking.create_agent_dhcp_network(agent_id, create_attributes)
+        rescue Core::Api::ResponseError => e
+          # neutron returns invalid json response 'null'
+          raise e unless e.message.match?("unexpected token at 'null'")
+        end
+        attributes[:id] = agent_id
+        # we assume creation worked and return input attributes
+        attributes
+      end
+    end
+  end
+end

--- a/plugins/networking/app/views/networking/networks/_item.html.haml
+++ b/plugins/networking/app/views/networking/networks/_item.html.haml
@@ -29,6 +29,9 @@
             %li= link_to 'Edit', plugin('networking').send("edit_networks_#{@network_type}_path", network.id), data: {modal: true}
             %li= link_to 'Manage Subnets', plugin('networking').networks_manage_subnets_path(network.id), data: {modal: true}
             - added = true
+          - if current_user.is_allowed?("networking:network_get:dhcp_agents", network: network)
+            %li= link_to 'Manage DHCP Agents', plugin('networking').send("networks_#{@network_type}_dhcp_agents_path", network.id), data: {modal: true}
+            - added = true
           - if current_user.is_allowed?("networking:rbac_policy_list", network: network)
             %li= link_to 'Access Control', plugin('networking').send("networks_#{@network_type}_access_index_path", network.id), data: {modal: true}
             - added = true

--- a/plugins/networking/app/views/networking/networks/dhcp_agents/_dhcp_agent_item.html.haml
+++ b/plugins/networking/app/views/networking/networks/dhcp_agents/_dhcp_agent_item.html.haml
@@ -1,0 +1,14 @@
+%tr{id: "dhcp_agent_#{dhcp_agent.id}"}
+  %td= dhcp_agent.host
+  %td= dhcp_agent.status
+  %td= dhcp_agent.admin_state
+
+  %td.snug
+    - if current_user.is_allowed?("networking:network_dhcp_agent_delete", {dhcp_agent: dhcp_agent})
+      = link_to plugin('networking').send("networks_#{@network_type}_dhcp_agent_path", @network_id, dhcp_agent.id),
+        class: "btn btn-danger btn-sm",
+        method: :delete,
+        data: { confirm: 'Are you sure you want to remove this DHCP Agent?', ok: "Yes, remove it", confirmed: :loading_status },
+        remote: true do
+        %i.fa.fa-trash.fa-fw
+        Remove

--- a/plugins/networking/app/views/networking/networks/dhcp_agents/_new_dhcp_agent_form.html.haml
+++ b/plugins/networking/app/views/networking/networks/dhcp_agents/_new_dhcp_agent_form.html.haml
@@ -1,0 +1,16 @@
+%tr
+  %td.form_content
+
+    = form_for :dhcp, url: plugin('networking').send("networks_#{@network_type}_dhcp_agents_path", @network_id), method: :post, remote: true, html: {data: {inline:true}, class: 'hidden', id: 'new_dhcp_form'} do |f|
+      %p.alert.alert-error.hidden
+      .input-group
+        = f.collection_select :agent_id, @new_dhcp_agents, :id, :host, class: 'form-control'
+
+        %span.input-group-btn
+          = f.submit 'Add', class: 'btn btn-primary', data: { disable_with: 'Please wait...' }
+
+  %td#plus{class: @new_dhcp_agents.length == 0 ? 'hidden' : ''}
+    = link_to '+', '#', class: 'btn btn-primary', data: {control_dhcp_form: '#new_dhcp_form'}
+
+  :javascript
+    $('[data-control-dhcp-form]').dhcpFormControl();

--- a/plugins/networking/app/views/networking/networks/dhcp_agents/create.js.erb
+++ b/plugins/networking/app/views/networking/networks/dhcp_agents/create.js.erb
@@ -1,0 +1,18 @@
+location.reload();
+// FIXME: ideally handle without full reload, need to fill the new dhcp_agent element somehow
+// but the create request response doesn't contain anything
+// <% if @dhcp_agent.errors.empty? %>
+//   $('#new_dhcp_form .alert-error').empty().addClass('hidden');
+//   var html="<%= j(render(partial: 'networking/networks/dhcp_agents/dhcp_agent_item', locals:{dhcp_agent: @dhcp_agent})) %>"
+//
+//
+//   if($("table#dhcp_agents tr[data-empty]").length==1) {
+//     $("table#dhcp_agents tr[data-empty]").replaceWith(html);
+//   } else {
+//     $("table#dhcp_agents tbody").prepend(html);
+//   }
+//
+//   $('[data-control-dhcp-form]').dhcpFormControl('hide');
+// <% else %>
+//   $('#new_dhcp_form .alert-error').html('<%=@dhcp_agent.errors.full_messages.to_sentence%>').removeClass('hidden');
+// <% end %>

--- a/plugins/networking/app/views/networking/networks/dhcp_agents/destroy.js.erb
+++ b/plugins/networking/app/views/networking/networks/dhcp_agents/destroy.js.erb
@@ -1,0 +1,4 @@
+location.reload();
+// FIXME: ideally handle without full reload, need to re-calculate the select options somehow
+// $("#dhcp_agent_<%=params[:id]%>").remove();
+// $("#plus").removeClass('hidden');

--- a/plugins/networking/app/views/networking/networks/dhcp_agents/index.html.haml
+++ b/plugins/networking/app/views/networking/networks/dhcp_agents/index.html.haml
@@ -1,0 +1,28 @@
+= content_for :title do
+  DHCP Agents
+
+%div{class: modal? ? 'modal-body' : ''}
+  %table.table#dhcp_agents
+    %thead
+      %tr
+        %th Agent Hosting Device
+        %th Status
+        %th Admin State
+        %th.snug
+    %tbody
+      - if @dhcp_agents.length == 0
+        %tr
+          %td{colspan: 5} No DHCP Agent present!
+      - else
+        - @dhcp_agents.each do | dhcp_agent |
+          = render partial: 'dhcp_agent_item', locals: {dhcp_agent: dhcp_agent}
+
+      - if current_user.is_allowed?("networking:network_dhcp_agent_create",{tenant_id:@scoped_project_id, network: @network})
+        = render partial: 'networking/networks/dhcp_agents/new_dhcp_agent_form'
+
+
+%div.buttons{class: modal? ? 'modal-footer' : ''}
+  - if modal?
+    %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Cancel"}} Cancel
+  - else
+    = link_to "Cancel", plugin('networking').send("networks_#{@network_type}_index_url"), class: 'btn btn-default'

--- a/plugins/networking/config/policy.json
+++ b/plugins/networking/config/policy.json
@@ -28,6 +28,10 @@
   "networking:network_external_update": "rule:context_is_cloud_network_admin",
   "networking:network_external_delete": "rule:context_is_cloud_network_admin",
   "networking:network_get:segments": "rule:context_is_network_viewer",
+  "networking:network_get:dhcp_agents": "rule:context_is_cloud_network_admin",
+
+  "networking:network_dhcp_agent_create": "rule:context_is_cloud_network_admin",
+  "networking:network_dhcp_agent_delete": "rule:context_is_cloud_network_admin",
 
   "networking:router_create": "rule:context_is_network_admin",
   "networking:router_update": "rule:context_is_network_admin and project_id:%(router.tenant_id)s",

--- a/plugins/networking/config/routes.rb
+++ b/plugins/networking/config/routes.rb
@@ -23,6 +23,7 @@ Networking::Engine.routes.draw do
     %i[external private].each do |type|
       resources type do
         resources :access
+        resources :dhcp_agents
       end
     end
 


### PR DESCRIPTION
stolen from network access the js could be more functional instead of the whole reloading 🙄 

functionality provided works: add+remove dhcp agent from network as cloud_network_admin - that was a handy admin function in horizon 💀 

@andypf okay with you? feel free to improve on the js and the look 😉 