### PR TITLE
Adds Automatic Changelog Generation

### DIFF
--- a/contrib/elektra-changelog-builder/.github_changelog_generator
+++ b/contrib/elektra-changelog-builder/.github_changelog_generator
@@ -1,0 +1,4 @@
+project=elektra
+user=sapcc
+exclude_tags_regex=v1.0.0+.+
+output=/host/CHANGELOG.md

--- a/contrib/elektra-changelog-builder/Dockerfile
+++ b/contrib/elektra-changelog-builder/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6
+
+ENV GITHUB_CHANGELOG_GENERATOR_VERSION "1.14.3"
+
+RUN apk --no-cache add ruby ruby-json libstdc++ tzdata bash ca-certificates
+RUN echo 'gem: --no-document' > /etc/gemrc
+RUN gem install github_changelog_generator --version $GITHUB_CHANGELOG_GENERATOR_VERSION
+
+COPY .github_changelog_generator /
+
+CMD github_changelog_generator --token $GITHUB_TOKEN

--- a/contrib/elektra-changelog-builder/Makefile
+++ b/contrib/elektra-changelog-builder/Makefile
@@ -1,0 +1,19 @@
+SHELL    := /bin/sh
+DATE     := $(shell date +%Y%m%d%H%M%S)
+VERSION  ?= v$(DATE)
+IMAGE    := sapcc/elektra-changelog-builder
+
+GITHUB_CHANGELOG_GENERATOR_VERSION := 1.14.3
+BUILD_ARGS = --build-arg GITHUB_CHANGELOG_GENERATOR_VERSION=$(GITHUB_CHANGELOG_GENERATOR_VERSION)
+
+.PHONY: build
+
+.PHONY: all
+all: build push
+
+build:
+	docker build $(BUILD_ARGS) -t $(IMAGE):$(VERSION) -t $(IMAGE):latest .
+
+push:
+	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE):latest


### PR DESCRIPTION
This commits adds a Docker image that includes a tool that automatically
generates changelogs.

See: https://github.com/skywinder/github-changelog-generator

This tool relies on Github metadata to generate the Changelog. This has
the advantage that it knows more than the Git history e.g. PRs,
Labels...

The here proposed workflow is to not include the generation of the
changelog into CI, but rather manually run it for each major version.
It's easy enough:

  rm CHANGELOG.md
  make CHANGELOG.md

Fixes #196