### PR TITLE
Compute::Flavor.save: do not fail when creating new flavor

### DIFF
--- a/plugins/compute/app/models/compute/flavor.rb
+++ b/plugins/compute/app/models/compute/flavor.rb
@@ -30,7 +30,12 @@ module Compute
       return false unless valid?
 
       rescue_api_errors do
-        @service.delete_flavor(id) unless id.blank?
+        begin
+          @service.delete_flavor(id) unless id.blank?
+        rescue ::Elektron::Errors::ApiResponse => e
+          # 404 while deleting is not an error
+          raise e unless e.code == 404
+        end
         # create the new flavor. Caution: if this operation fails then it is
         # just a delete.
         new_attributes = attributes_for_create


### PR DESCRIPTION
This is not working yet, but no idea why. There seems to be something horribly broken in the exception handling. For example, if I do this instead:

```ruby
begin
  @service.delete_flavor(id) unless id.blank?
rescue => e
  pp(e.class)
  pp(e.code)
  raise StandardError, 'manual error'
end
```

I see the output of the `pp()`, but the UI shows the error message from `e` rather than "manual error". WTF.