### PR TITLE
discourage remote security groups

### DIFF
--- a/plugins/networking/app/assets/javascripts/networking/plugin/security_group_rule.coffee
+++ b/plugins/networking/app/assets/javascripts/networking/plugin/security_group_rule.coffee
@@ -41,7 +41,9 @@ $(document).on 'modal:contentUpdated', (e) ->
       $form.find(".form-group.security_group_rule_remote_ip_prefix").removeClass('hidden')
       $form.find(".form-group.security_group_rule_remote_group_id").addClass('hidden')
       $form.find(".form-group.security_group_rule_ethertype").addClass('hidden')
+      $form.find("#wrapper_has_read_documentation").addClass('hidden')
     else
       $form.find(".form-group.security_group_rule_remote_ip_prefix").addClass('hidden')
       $form.find(".form-group.security_group_rule_remote_group_id").removeClass('hidden')
       $form.find(".form-group.security_group_rule_ethertype").removeClass('hidden')
+      $form.find("#wrapper_has_read_documentation").removeClass('hidden')

--- a/plugins/networking/app/views/networking/security_groups/rules/new.html.haml
+++ b/plugins/networking/app/views/networking/security_groups/rules/new.html.haml
@@ -41,6 +41,11 @@
             selected: @security_groups.first.id,
             wrapper_html: {class: ("hidden" unless @rule.remote_ip_prefix.blank?)} }
 
+          %p#wrapper_has_read_documentation{class: "text-danger " + ("hidden" unless @rule.remote_ip_prefix.blank?)}
+            This should only be used if you operate within the documented boundaries. Please review the
+            = succeed '.' do
+              = link_to 'recommendations for security group design', "#{@sap_docu_url}/docs/network/secgroup-design.html", target: '_blank'
+
           = f.input :ethertype, {label: 'Ether Type',
             as: :select,
             collection: [["IPv4","ipv4"],["IPv6","ipv6"]],

--- a/plugins/networking/config/security_group_rule_types.yml
+++ b/plugins/networking/config/security_group_rule_types.yml
@@ -7,7 +7,7 @@ descriptions:
   rules: "Rules define which traffic is allowed to instances assigned to the security group. A security group rule consists of three main parts: Type, Port Range and Remote Source."
   type: "You can specify the desired rule template or use custom rules, the options are Custom TCP Rule, Custom UDP Rule, or Custom ICMP Rule."
   port_range: "For TCP and UDP rules you may choose to open either a single port or a range of ports. For as range provide the starting and ending ports devided by minus (e.g. 0-80). For ICMP rules you instead specify an ICMP type and code in the spaces provided." 
-  remote: "You must specify the source of the traffic to be allowed via this rule. You may do so either in the form of an IP address block (CIDR) or via a source group (Security Group). Selecting a security group as the source will allow any other instance in that security group access" 
+  remote: "You must specify the source of the traffic to be allowed via this rule. You may do so either in the form of an IP address block (CIDR, recommended) or via a source group (Security Group, not recommended). Selecting a security group as the source will allow any other instance in that security group access."
    
 predefined_types:  
   custom_tcp_rule:


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/24696/38028098-1b6bc884-3292-11e8-80cb-f5c51025257d.png)

I previously considered a design where the user has to confirm that they read the documentation by checking a checkbox (like when agreeing to ToS), but that is probably too drastic.