### PR TITLE
Add policy rules for viewer roles

### DIFF
--- a/plugins/identity/config/policy.json
+++ b/plugins/identity/config/policy.json
@@ -3,10 +3,11 @@
   "admin_and_matching_target_project_domain_id": "role:admin and domain_id:%(target.project.domain_id)s",
   "admin_and_matching_target_project_id": "role:admin and project_id:%(target.project.id)s",
   "admin_and_matching_project_domain_id": "rule:admin_required and domain_id:%(project.domain_id)s",
+  "cloud_viewer": "role:cloud_identity_viewer or rule:service_role or rule:cloud_admin",
 
   "identity:project_get": "rule:cloud_admin or rule:admin_and_matching_target_project_domain_id or project_id:%(target.project.id)s",
   "identity:project_show_wizard": "rule:cloud_admin or rule:admin_and_matching_target_project_domain_id or project_id:%(target.project.id)s",
-  "identity:project_list": "rule:cloud_admin or rule:admin_and_matching_domain_id",
+  "identity:project_list": "rule:cloud_admin or rule:admin_and_matching_domain_id or rule:cloud_viewer",
   "identity:project_user_projects": "@",
   "identity:project_update": "rule:cloud_admin or rule:admin_and_matching_target_project_domain_id or rule:admin_and_matching_target_project_id",
   "identity:project_delete": "rule:cloud_admin or rule:admin_and_matching_target_project_domain_id or rule:admin_and_matching_target_project_id",
@@ -18,7 +19,7 @@
   "identity:project_download_openrc": "not(project_id:nil)",
   "identity:project_web_console": "rule:cloud_admin or rule:admin_and_matching_target_project_domain_id or rule:admin_and_matching_target_project_id",
 
-  "identity:domain_list": "rule:cloud_admin",
+  "identity:domain_list": "rule:cloud_admin or rule:cloud_viewer",
   "identity:domain_get": "(role:admin or role:Member or role:member) and domain_id:%(target.domain_id)s",
 
   "identity:credential_get": "rule:admin_required",
@@ -27,15 +28,15 @@
   "identity:credential_update": "rule:admin_required",
   "identity:credential_delete": "rule:admin_required or user_id:%(target.credential.user_id)s",
 
-  "identity:project_member_list": "rule:cloud_admin or role:admin or role:member or role:Member",
+  "identity:project_member_list": "rule:cloud_admin or role:admin or role:member or role:Member or rule:cloud_viewer",
   "identity:project_member_create": "rule:cloud_admin or role:admin",
   "identity:project_member_update": "rule:cloud_admin or role:admin",
 
-  "identity:project_group_list": "rule:cloud_admin or role:admin or role:member or role:Member",
+  "identity:project_group_list": "rule:cloud_admin or role:admin or role:member or role:Member or rule:cloud_viewer",
   "identity:project_group_create": "rule:cloud_admin or role:admin",
   "identity:project_group_update": "rule:cloud_admin or role:admin",
 
-  "identity:group_list": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s)",
+  "identity:group_list": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s) or rule:cloud_viewer",
   "identity:group_create": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s)",
   "identity:group_update": "rule:cloud_admin or (role:admin and domain_id:%(group.domain_id)s)",
   "identity:group_delete": "rule:cloud_admin or (role:admin and domain_id:%(group.domain_id)s)",
@@ -43,7 +44,7 @@
   "identity:group_add_member": "rule:cloud_admin or (role:admin and domain_id:%(group.domain_id)s)",
   "identity:group_remove_member": "rule:cloud_admin or (role:admin and domain_id:%(group.domain_id)s)",
 
-  "identity:user_list": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s)",
-  "identity:user_show": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s)",
+  "identity:user_list": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s) or rule:cloud_viewer",
+  "identity:user_show": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s) or rule:cloud_viewer",
   "identity:user_update": "rule:cloud_admin or (role:admin and domain_id:%(domain_id)s)"
 }

--- a/plugins/image/config/policy.json
+++ b/plugins/image/config/policy.json
@@ -1,4 +1,6 @@
 {
+  "image_viewer": "role:image_viewer",
+  
   "image:image_owner": "project_id:%(image.owner)s",
   "image:image_creator": "user_id:%(image.user_id)s",
   "image:cloud_admin": "role:cloud_image_admin",
@@ -7,8 +9,8 @@
   "image:image_is_shared": "'shared'==%(image.visibility)s",
   "image:image_is_community": "'community'==%(image.visibility)s",
 
-  "image:image_get": "role:admin or role:Member or role:member",
-  "image:image_list": "role:admin or role:Member or role:member",
+  "image:image_get": "role:admin or role:Member or role:member or rule:image_viewer",
+  "image:image_list": "role:admin or role:Member or role:member or rule:image_viewer",
   "image:image_create": "role:admin",
   "image:image_update": "role:admin or user_id:%(image.user_id)s",
   "image:image_delete": "project_id:%(image.owner)s",

--- a/plugins/masterdata_cockpit/config/policy.json
+++ b/plugins/masterdata_cockpit/config/policy.json
@@ -1,5 +1,5 @@
 {
-  "masterdata_cockpit:masterdata_get": "role:admin",
+  "masterdata_cockpit:masterdata_get": "role:admin or role:masterdata_viewer",
   "masterdata_cockpit:masterdata_edit": "rule:project_admin or rule:domain_admin",
   "masterdata_cockpit:masterdata_create": "rule:project_admin or rule:domain_admin"
 }


### PR DESCRIPTION
This adds the necessary policy entries to support viewer roles for all plugins that were missing them: identity, images, masterdata.