### PR TITLE
Fix automation_script permissions typo

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -12,7 +12,7 @@ module Compute
                                       attach_interface create_interface
                                       remove_interface detach_interface
                                       detach_floatingip new_snapshot update_item new_size
-                                      automation_script, new_status]
+                                      automation_script new_status]
 
     def index
       per_page = params[:per_page] || 20


### PR DESCRIPTION
Customer with only one `member` role was not allowed to create an automation for a node.

```
{"error":"You are not authorized to view this page. Please check (role assignments) if you have one of the           following roles: admin."}
```