### PR TITLE
allow role-assignment-management of baremetal & cfm roles

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -1,6 +1,10 @@
 ALLOWED_ROLES = %w(
   admin
   audit_viewer
+  baremetal_admin
+  baremetal_viewer
+  cfm_admin
+  cfm_user
   compute_admin
   compute_viewer
   dns_viewer


### PR DESCRIPTION
Can you please check if there is any reason for not allowing management of these roles in elektra?
The S4 team is stuck, since they are missing these..