### PR TITLE
Webpacker host option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 #db:    postgres -D /usr/local/var/postgres
 rails:  bundle exec rails s Puma -b 0.0.0.0 -p $PORT
-webpack: bundle exec webpack-dev-server --host 127.0.0.1
+webpack: bundle exec webpack-dev-server
 #log:   tail -f log/development.log

--- a/env.sample
+++ b/env.sample
@@ -47,3 +47,6 @@ MONSOON_DASHBOARD_CAM_URL=<cam-url>
 # TWO_FACTOR_AUTH_DOMAINS = domain1,domain2|empty
 # TWO_FACTOR_RADIUS_SERVERS = <jump-server>
 # TWO_FACTOR_RADIUS_SECRET = SECRET
+
+# overwrite default localhost from config/webpacker.yml
+# WEBPACKER_DEV_SERVER_HOST=0.0.0.0


### PR DESCRIPTION
`--host` option is not working https://github.com/webpack/webpack-dev-server/issues/882
to overwrite the host from webpacker.yml config use `WEBPACKER_DEV_SERVER_HOST=x.x.x.x` in `.env`