### PR TITLE
Automation policies

### DIFF
--- a/app/controllers/concerns/error_renderer.rb
+++ b/app/controllers/concerns/error_renderer.rb
@@ -18,13 +18,15 @@ module ErrorRenderer
 
   # instance methods
   module InstanceMethods
-    def render_exception_page(exception,map={})
+    def render_exception_page(exception, map = {})
       raise exception if Rails.env.development? && ENV.key?('NO_EXCEPTION_PAGE')
+
       value = lambda do |param|
         v = map[param.to_sym] || map[param.to_s]
         return nil if v.nil?
         return exception.send(v).to_s if v.is_a?(Symbol)
         return v.call(exception, self).to_s if v.is_a?(Proc)
+
         return v.to_s
       end
 
@@ -38,53 +40,64 @@ module ErrorRenderer
 
       begin
         @title = value.call(:title) || exception.class.name.split('::').last.humanize
-        @description = value.call(:description) || (exception.message rescue exception.to_s)
-        @details = value.call(:details) || exception.class.name+"\n"+(exception.backtrace rescue '').join("\n")
+        @description = value.call(:description) || (begin
+                                                      exception.message
+                                                    rescue StandardError
+                                                      exception.to_s
+                                                    end)
+        @details = value.call(:details) || exception.class.name + "\n" + (begin
+                                                                        exception.backtrace
+                                                                      rescue StandardError
+                                                                        ''
+                                                                      end).join("\n")
         @exception_id = value.call(:exception_id) || request.uuid
         @warning = value.call(:warning) || false
         @status = value.call(:status) || status
-      rescue => e
+      rescue StandardError => e
         @title = e.class.name.split('::').last.humanize
         @description = e.message
-        @details = e.class.name+"\n"+(e.backtrace rescue '').join("\n")
+        @details = e.class.name + "\n" + (begin
+                                        e.backtrace
+                                      rescue StandardError
+                                        ''
+                                      end).join("\n")
         @exception_id = request.uuid
         @warning = false
         @status = 503
       end
 
-      unless @warning
+      if @warning
+        if request.xhr? && params[:polling_service]
+          render '/application/exceptions/error_polling.js', format: 'JS'
+        else
+          # byebug
+          respond_to do |format|
+            format.html { render '/application/exceptions/warning.html' }
+            format.js { render '/application/exceptions/warning.js' }
+            format.json { render json: { error: @description }, status: @status }
+          end
+        end
+      else
         logger.error("#{@exception_id}: #{@title}. #{@description}")
 
-        unless map[:sentry]==false
+        unless map[:sentry] == false
           Raven::Rack.capture_exception(exception, request.env)
           @exception_id = Raven.last_event_id if Raven.last_event_id
         end
         @sentry_event_id   = Raven.last_event_id
-        @sentry_public_dsn = URI.parse(ENV['SENTRY_DSN']).tap {|u| u.password=nil}.to_s if ENV['SENTRY_DSN']
+        @sentry_public_dsn = URI.parse(ENV['SENTRY_DSN']).tap { |u| u.password = nil }.to_s if ENV['SENTRY_DSN']
         @sentry_user       = { name: current_user.full_name || current_user.name, email: current_user.email } if current_user
 
         # no render error if polling service
         unless params[:polling_service]
           respond_to do |format|
             format.html { render '/application/exceptions/error.html' }
-            format.js { render "/application/exceptions/error.js" }
-            format.json {render json: {error: @description}, status: @status}
-          end
-        end
-      else
-        if request.xhr? && params[:polling_service]
-          render "/application/exceptions/error_polling.js", format: "JS"
-        else
-          # byebug
-          respond_to do |format|
-            format.html { render '/application/exceptions/warning.html' }
-            format.js { render "/application/exceptions/warning.js" }
-            format.json { render json: {error: @description}, status: @status }
+            format.js { render '/application/exceptions/error.js' }
+            format.json { render json: { error: @description }, status: @status }
           end
         end
       end
     rescue AbstractController::DoubleRenderError => _e
-
     end
   end
 
@@ -102,7 +115,7 @@ module ErrorRenderer
 
       exception_classes.each do |exception_class|
         if exception_class.is_a?(Hash)
-          exception_mapping[exception_class.keys.first.to_s]=exception_class.values.first
+          exception_mapping[exception_class.keys.first.to_s] = exception_class.values.first
           klasses << exception_class.keys.first.to_s
         else
           klasses << exception_class
@@ -113,18 +126,16 @@ module ErrorRenderer
         map = exception_mapping[exception.class.name]
         unless map
           klass = nil
-          exception_mapping.each do |class_name,mapping|
+          exception_mapping.each do |class_name, mapping|
             found_class = eval(class_name)
             next if klass && found_class > klass
 
-            if found_class > exception.class
-              map = mapping
-            end
+            map = mapping if found_class > exception.class
           end
           map ||= {}
         end
 
-        render_exception_page(exception,map)
+        render_exception_page(exception, map)
       end
     end
   end

--- a/app/controllers/concerns/error_renderer.rb
+++ b/app/controllers/concerns/error_renderer.rb
@@ -72,8 +72,8 @@ module ErrorRenderer
         else
           # byebug
           respond_to do |format|
-            format.html { render '/application/exceptions/warning.html' }
-            format.js { render '/application/exceptions/warning.js' }
+            format.html { render '/application/exceptions/warning.html', status: @status }
+            format.js { render '/application/exceptions/warning.js', status: @status }
             format.json { render json: { error: @description }, status: @status }
           end
         end
@@ -91,8 +91,8 @@ module ErrorRenderer
         # no render error if polling service
         unless params[:polling_service]
           respond_to do |format|
-            format.html { render '/application/exceptions/error.html' }
-            format.js { render '/application/exceptions/error.js' }
+            format.html { render '/application/exceptions/error.html', status: @status }
+            format.js { render '/application/exceptions/error.js', status: @status }
             format.json { render json: { error: @description }, status: @status }
           end
         end

--- a/plugins/audit/spec/controllers/application_controller_spec.rb
+++ b/plugins/audit/spec/controllers/application_controller_spec.rb
@@ -3,19 +3,23 @@ require 'spec_helper'
 describe Audit::ApplicationController, type: :controller do
   routes { Audit::Engine.routes }
 
-  default_params = {domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id}
+  default_params = { domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id }
 
   before(:all) do
-    FriendlyIdEntry.find_or_create_entry('Domain',nil,default_params[:domain_id],'default')
-    FriendlyIdEntry.find_or_create_entry('Project',default_params[:domain_id],default_params[:project_id],default_params[:project_id])
+    FriendlyIdEntry.find_or_create_entry('Domain', nil, default_params[:domain_id], 'default')
+    FriendlyIdEntry.find_or_create_entry('Project', default_params[:domain_id], default_params[:project_id], default_params[:project_id])
   end
 
   before :each do
-    stub_authentication
+    stub_authentication do |token|
+      token['roles'].delete_if { |h| h['id'] == 'audit_role' }
+      token['roles'] << { 'id' => 'audit_role', 'name' => 'audit_viewer' }
+      token
+    end
   end
 
   describe "GET 'index'" do
-    it "returns http success" do
+    it 'returns http success' do
       get :index, params: default_params
       expect(response).to be_success
     end

--- a/plugins/automation/app/assets/javascripts/automation/automation.coffee
+++ b/plugins/automation/app/assets/javascripts/automation/automation.coffee
@@ -39,6 +39,8 @@
         $(".flashes").append($(data).contents())
       else
         $(".flashes").append(data)
+    error: (request, status, error) ->
+      $(".flashes").append(request.responseText)
     complete: () ->
       spinner.addClass('hide')
       btn_group.removeClass('hide')

--- a/plugins/automation/app/controllers/automation/application_controller.rb
+++ b/plugins/automation/app/controllers/automation/application_controller.rb
@@ -24,5 +24,34 @@ module Automation
     #     }
     #   }
     # ]
+
+    rescue_from 'MonsoonOpenstackAuth::Authorization::SecurityViolation' do |exception|
+      if exception.resource[:action] == 'index' && exception.resource[:controller] == 'automation/nodes'
+        @title = 'Unauthorized'
+        @status = 401
+        @description = 'You are not authorized to view this page.'
+        if exception.respond_to?(:involved_roles) && exception.involved_roles && exception.involved_roles.length.positive?
+          @description += " Please check (role assignments) if you have one of the following roles: #{exception.involved_roles.flatten.join(', ')}."
+        end
+        render '/automation/shared/warning.html', status: @status
+      end
+
+      options = {
+        title: 'Unauthorized',
+        sentry: false,
+        warning: true,
+        status: 401,
+        description: lambda do |e, _c|
+          m = 'You are not authorized to view this page.'
+          if e.involved_roles && e.involved_roles.length.positive?
+            m += " Please check (role assignments) if you have one of the \
+          following roles: #{e.involved_roles.flatten.join(', ')}."
+          end
+          m
+        end
+      }
+
+      render_exception_page(exception, options)
+    end
   end
 end

--- a/plugins/automation/app/controllers/automation/automations_controller.rb
+++ b/plugins/automation/app/controllers/automation/automations_controller.rb
@@ -1,5 +1,8 @@
 module Automation
   class AutomationsController < ::Automation::ApplicationController
+    authorization_context 'automation'
+    authorization_required
+
     before_action :automation, only: %i[show edit]
 
     PER_PAGE = 10

--- a/plugins/automation/app/controllers/automation/automations_controller.rb
+++ b/plugins/automation/app/controllers/automation/automations_controller.rb
@@ -1,14 +1,13 @@
 module Automation
-
   class AutomationsController < ::Automation::ApplicationController
-    before_action :automation, only: [:show, :edit]
+    before_action :automation, only: %i[show edit]
 
     PER_PAGE = 10
     AUTOMATION_TYPE_UNKNOWN = I18n.t('automation.errors.automation_type_unknown')
     AUTOMATION_TYPE_MANIPULATED = I18n.t('automation.errors.automation_type_manipulated')
 
     def index
-      @pag_params = {automation: {page: 0}, run: {page: 0}}
+      @pag_params = { automation: { page: 0 }, run: { page: 0 } }
       if request.xhr?
         if params[:model] == 'run'
           @pag_params[:run][:page] = params[:page]
@@ -26,7 +25,7 @@ module Automation
     end
 
     def index_update_runs
-      @pag_params = {automation: {page: 0}, run: {page: 0}}
+      @pag_params = { automation: { page: 0 }, run: { page: 0 } }
       @pag_params[:run][:page] = params[:page]
       runs_with_jobs(params[:page])
       render partial: 'table_runs'
@@ -34,7 +33,7 @@ module Automation
 
     def new
       @automation_types = ::Automation::Automation.types
-      @automation = ::Automation::Forms::Automation.new()
+      @automation = ::Automation::Forms::Automation.new
     end
 
     def create
@@ -43,7 +42,7 @@ module Automation
 
       # check automation type
       form_params = automation_params
-      type = form_params.fetch('type',"")
+      type = form_params.fetch('type', '')
 
       # create automation type
       @automation = automation_form(type, form_params)
@@ -51,28 +50,27 @@ module Automation
         # in case someone manipulate the type we set the default chef type back manually
         @automation = ::Automation::Forms::ChefAutomation.new(form_params.merge(type: 'chef'))
         flash.now[:error] = AUTOMATION_TYPE_UNKNOWN
-        return render action: "new"
+        return render action: 'new'
       end
 
       # validate and check
       if @automation.save(services.automation.automation_service)
-        #flash[:success] = "Automation #{@automation.name} was successfully added."
+        # flash[:success] = "Automation #{@automation.name} was successfully added."
         redirect_to plugin('automation').automations_path
       else
-         render action: "new"
+        render action: 'new'
       end
     rescue Exception => e
       Rails.logger.error e
-      flash.now[:error] = I18n.t("automation.errors.automation_creation_error")
-      render action: "new"
+      flash.now[:error] = I18n.t('automation.errors.automation_creation_error')
+      render action: 'new'
     end
 
     def show
       @automation_types = ::Automation::Automation.types
     end
 
-    def edit
-    end
+    def edit; end
 
     def update
       @automation_form = nil
@@ -80,11 +78,11 @@ module Automation
 
       # get original data and compare type
       orig_automation = services.automation.automation(form_params['id'])
-      type = form_params.fetch('type',"")
+      type = form_params.fetch('type', '')
       if type != orig_automation.type
-        @automation = automation_form(orig_automation.type, form_params.merge({type: orig_automation.type}))
+        @automation = automation_form(orig_automation.type, form_params.merge(type: orig_automation.type))
         flash.now[:error] = AUTOMATION_TYPE_MANIPULATED
-        return render action: "edit"
+        return render action: 'edit'
       end
 
       # create model
@@ -92,15 +90,15 @@ module Automation
 
       # validate and save
       if @automation.update(services.automation.automation_service)
-        #flash[:success] = "Automation #{@automation.name} was successfully updated."
+        # flash[:success] = "Automation #{@automation.name} was successfully updated."
         redirect_to plugin('automation').automations_path
       else
-        render action: "edit"
+        render action: 'edit'
       end
     rescue Exception => e
       Rails.logger.error e.message
       flash[:error] = I18n.t('automation.errors.automation_update_error')
-      render action: "edit"
+      render action: 'edit'
     end
 
     def destroy
@@ -108,7 +106,7 @@ module Automation
       automation.destroy
       automations(1)
       runs_with_jobs(1)
-      flash.now[:success] = I18n.t("automation.messages.automation_removed_successfully", name: automation.name)
+      flash.now[:success] = I18n.t('automation.messages.automation_removed_successfully', name: automation.name)
       render template: 'automation/automations/update_item.js'
     rescue Exception => e
       Rails.logger.error e.message
@@ -119,14 +117,18 @@ module Automation
     end
 
     def update_item
-      @automation = services.automation.automation(params[:id]) rescue nil
+      @automation = begin
+                      services.automation.automation(params[:id])
+                    rescue StandardError
+                      nil
+                    end
     end
 
     private
 
     def automation
       automation = services.automation.automation(params[:id])
-      @automation = ::Automation::Forms::Automation.new( automation.attributes_to_form)
+      @automation = ::Automation::Forms::Automation.new(automation.attributes_to_form)
     end
 
     def automations(page)
@@ -136,18 +138,18 @@ module Automation
     def runs_with_jobs(page)
       runs = services.automation.automation_runs(page, PER_PAGE)
       runs.each do |run|
-        unless run.attributes['jobs'].nil?
-          run.attributes['jobs_states'] = {'queued' => 0, 'failed' => 0, 'complete' => 0, 'executing' => 0}
-          run.attributes['jobs'].each do |job_id|
-            begin
-              job = services.automation.job(job_id)
-              run.attributes['jobs_states'][job.status] += 1
-            rescue ArcClient::ApiError => exception
-              if exception.code == 404
-                # do nothing
-              else
-                raise exception
-              end
+        next if run.attributes['jobs'].nil?
+
+        run.attributes['jobs_states'] = { 'queued' => 0, 'failed' => 0, 'complete' => 0, 'executing' => 0 }
+        run.attributes['jobs'].each do |job_id|
+          begin
+            job = services.automation.job(job_id)
+            run.attributes['jobs_states'][job.status] += 1
+          rescue ArcClient::ApiError => exception
+            if exception.code == 404
+              # do nothing
+            else
+              raise exception
             end
           end
         end
@@ -156,29 +158,24 @@ module Automation
     end
 
     def automation_form(type, form_params)
-      if type.downcase == ::Automation::Automation::Types::CHEF.downcase
-       return ::Automation::Forms::ChefAutomation.new(form_params)
-      elsif type.downcase == ::Automation::Automation::Types::SCRIPT.downcase
-        return ::Automation::Forms::ScriptAutomation.new(form_params)
-      else
-        return nil
+      if type.casecmp(::Automation::Automation::Types::CHEF).zero?
+        ::Automation::Forms::ChefAutomation.new(form_params)
+      elsif type.casecmp(::Automation::Automation::Types::SCRIPT).zero?
+        ::Automation::Forms::ScriptAutomation.new(form_params)
       end
     end
 
     def automation_params
       p = params.to_unsafe_hash
-      unless p['forms_automation'].blank?
-        return p.fetch('forms_automation', {})
-      end
+      return p.fetch('forms_automation', {}) unless p['forms_automation'].blank?
       unless p['forms_chef_automation'].blank?
         return p.fetch('forms_chef_automation', {})
       end
       unless p['forms_script_automation'].blank?
         return p.fetch('forms_script_automation', {})
       end
-      return {}
+
+      {}
     end
-
   end
-
 end

--- a/plugins/automation/app/controllers/automation/jobs_controller.rb
+++ b/plugins/automation/app/controllers/automation/jobs_controller.rb
@@ -1,5 +1,8 @@
 module Automation
   class JobsController < ::Automation::ApplicationController
+    authorization_context 'automation'
+    authorization_required
+
     def show
       @job = services.automation.job(params[:id])
 

--- a/plugins/automation/app/controllers/automation/nodes_controller.rb
+++ b/plugins/automation/app/controllers/automation/nodes_controller.rb
@@ -2,6 +2,9 @@ require 'ostruct'
 
 module Automation
   class NodesController < ::Automation::ApplicationController
+    authorization_context 'automation'
+    authorization_required
+
     before_action :search_options, only: %i[index index_update]
     before_action :nodes_with_jobs, only: %i[index index_update]
     before_action :automations, only: %i[index index_update]
@@ -72,6 +75,7 @@ module Automation
       @errors = [{ key: 'danger', message: I18n.t('automation.errors.node_install_show_instructions_error') }]
     end
 
+    # update node tags
     def update
       @node_form = ::Automation::Forms::NodeTags.new(params.to_unsafe_hash['forms_node_tags'])
       @error = false

--- a/plugins/automation/app/controllers/automation/runs_controller.rb
+++ b/plugins/automation/app/controllers/automation/runs_controller.rb
@@ -1,18 +1,20 @@
 module Automation
-
   class RunsController < ::Automation::ApplicationController
-    before_action :run, only: [:show, :show_log]
-    NO_DATA_FOUND = 'No log available.'
+    authorization_context 'automation'
+    authorization_required
+
+    before_action :run, only: %i[show show_log]
+    NO_DATA_FOUND = 'No log available.'.freeze
     LINES_TRUNCATION = 25
 
     def show
       # get the jobs
-      list_run_jobs()
+      list_run_jobs
       @truncated_log = ::Automation::DataTruncation.new(@run.log)
     end
 
     def show_log
-      render :layout => false
+      render layout: false
     end
 
     # private
@@ -34,10 +36,7 @@ module Automation
             raise exception
           end
         end
-
       end
     end
-
   end
-
 end

--- a/plugins/automation/app/views/automation/automations/_table_automations.html.haml
+++ b/plugins/automation/app/views/automation/automations/_table_automations.html.haml
@@ -1,3 +1,5 @@
+- user_allowed = current_user.is_allowed?('automation:automation_update') || current_user.is_allowed?('automation:automation_delete')
+
 .automations_table
   %table.table
     %thead
@@ -6,11 +8,12 @@
         %th Type
         %th Repository
         %th Repository revision
-        %th.snug
+        - if user_allowed
+          %th.snug
     %tbody
       - if automations.empty?
         %tr
-          %td{colspan: 5} No automations available
+          %td{colspan: (user_allowed ? 5 : 4 )} No automations available
       - else
         -automations.each do | automation |
           = render partial: 'table_automations_item', locals: {automation: automation}

--- a/plugins/automation/app/views/automation/automations/_table_automations_item.html.haml
+++ b/plugins/automation/app/views/automation/automations/_table_automations_item.html.haml
@@ -1,14 +1,16 @@
+- user_allowed = current_user.is_allowed?('automation:automation_update') || current_user.is_allowed?('automation:automation_delete')
 %tr{id: "automation_#{automation.id}"}
   %td
     = link_to(automation.form_attribute('name'),  plugin('automation').automation_path(id: automation.id), data: {modal: true})
   %td= automation.form_attribute('type')
   %td= automation.form_attribute('repository')
   %td= automation.form_attribute('repository_revision')
-  %td
-    .btn-group
-      %button.btn.btn-default.btn-sm.dropdown-toggle{ type: "button", data: { toggle: "dropdown"}, aria: { expanded: true} }
-        %span.fa.fa-cog
+  - if user_allowed
+    %td
+      .btn-group
+        %button.btn.btn-default.btn-sm.dropdown-toggle{ type: "button", data: { toggle: "dropdown"}, aria: { expanded: true} }
+          %span.fa.fa-cog
 
-      %ul.dropdown-menu.dropdown-menu-right{ role:"menu"}
-        %li= link_to 'Edit',plugin('automation').edit_automation_path(id: automation.id), data: {modal: true}
-        %li= link_to 'Remove', plugin('automation').automation_path(id: automation.id), method: :delete, data: { confirm: "Are you sure you want to remove the automation #{automation.form_attribute('name')}?", ok: "Yes, remove it", confirmed: :loading_status}, remote: true
+        %ul.dropdown-menu.dropdown-menu-right{ role:"menu"}
+          %li= link_to 'Edit',plugin('automation').edit_automation_path(id: automation.id), data: {modal: true}
+          %li= link_to 'Remove', plugin('automation').automation_path(id: automation.id), method: :delete, data: { confirm: "Are you sure you want to remove the automation #{automation.form_attribute('name')}?", ok: "Yes, remove it", confirmed: :loading_status}, remote: true

--- a/plugins/automation/app/views/automation/automations/index.html.haml
+++ b/plugins/automation/app/views/automation/automations/index.html.haml
@@ -1,3 +1,4 @@
+- user_allowed = current_user.is_allowed?('automation:node_install') || current_user.is_allowed?('automation:node_delete')
 = render partial: 'automation/shared/nav.html', locals: {pane: 'automations'}
 
 .tab-content
@@ -8,9 +9,10 @@
       %h3
         Available Automations
 
-      .toolbar
-        .main-buttons
-          = link_to "New Automation", plugin('automation').new_automation_path, data: {modal: true}, class: 'btn btn-primary btn-sm'
+      - if current_user.is_allowed?('automation:automation_create')
+        .toolbar
+          .main-buttons
+            = link_to "New Automation", plugin('automation').new_automation_path, data: {modal: true}, class: 'btn btn-primary btn-sm'
 
       .js-table-automations{data: {toggle: 'paginationSpinner'}}
         = render partial: 'table_automations', locals: {automations: @automations}

--- a/plugins/automation/app/views/automation/nodes/_form_tags.html.haml
+++ b/plugins/automation/app/views/automation/nodes/_form_tags.html.haml
@@ -1,9 +1,10 @@
 %h3
   Tags
-  %small
-    = link_to '#', data: {modal: true}, class: 'js-node-tags-link-edit' do
-      %i.fa.fa-pencil
-    %i.fa.fa-pencil.js-node-tags-icon-read
+  - if current_user.is_allowed?('automation:node_update')
+    %small
+      = link_to '#', data: {modal: true}, class: 'js-node-tags-link-edit' do
+        %i.fa.fa-pencil
+      %i.fa.fa-pencil.js-node-tags-icon-read
 
 %p
   Use a tag to give this node a human readable display name. Ex:

--- a/plugins/automation/app/views/automation/nodes/_table_nodes.html.haml
+++ b/plugins/automation/app/views/automation/nodes/_table_nodes.html.haml
@@ -1,3 +1,4 @@
+- user_allowed = current_user.is_allowed?('automation:node_install') || current_user.is_allowed?('automation:node_delete')
 - data = {update_path: plugin('automation').nodes_path(page: @node_page, filter: @filter), update_interval: 10}
 .nodes_table.js-nodes-table{data: data}
   %table.table
@@ -9,11 +10,12 @@
         %th Tags
         %th Online
         %th Job history
-        %th.snug
+        - if user_allowed
+          %th.snug
     %tbody
       - if nodes.empty?
         %tr
-          %td{colspan: 7} No nodes available
+          %td{colspan: (user_allowed ? 7 : 6)} No nodes available
       - else
         -nodes.each do | node |
           = render partial: 'table_nodes_item', locals: {node: node, jobs: jobs[node.id.to_sym].fetch(:elements, {})}

--- a/plugins/automation/app/views/automation/nodes/_table_nodes_item.html.haml
+++ b/plugins/automation/app/views/automation/nodes/_table_nodes_item.html.haml
@@ -23,16 +23,20 @@
 
   %td.no-wrap
     = render partial: "table_nodes_item_jobs", locals: {jobs: jobs}
-  %td.no-wrap
-    %i.loading-spinner-section.hide{data: {node_id: node.id}}
-    .btn-group{data: {node_id: node.id}}
-      %button.btn.btn-default.btn-sm.dropdown-toggle{type: "button", data: {toggle: "dropdown"}, "aria-haspopup" => "true", "aria-expanded" => "false"}
-        %i.fa.fa-gears.fa-fw
-      %ul.dropdown-menu.dropdown-menu-right.dropdown-scrolly{ role:"menu"}
-        %li.dropdown-header
-          Run Automation
-        - @automations.each do |automation|
-          %li= link_to(automation.form_attribute('name'), "#", data: {toggle: "run_automation_link", node_id: node.id, link: plugin('automation').run_automation_nodes_path(node_id: node.id, automation_id: automation.form_attribute('id'), automation_name: automation.form_attribute('name')) })
 
-    = link_to plugin('automation').node_path(id: node.id), class: 'btn btn-default btn-sm', :method => 'delete', data: { confirm: "Are you sure you want to remove the node #{node.name}?", ok: "Yes, remove it", confirmed: :loading_status} do
-      %i.fa.fa-trash.fa-fw
+  - if current_user.is_allowed?('automation:node_install') || current_user.is_allowed?('automation:node_delete')
+    %td.no-wrap
+      %i.loading-spinner-section.hide{data: {node_id: node.id}}
+      - if current_user.is_allowed?('automation:node_install')
+        .btn-group{data: {node_id: node.id}}
+          %button.btn.btn-default.btn-sm.dropdown-toggle{type: "button", data: {toggle: "dropdown"}, "aria-haspopup" => "true", "aria-expanded" => "false"}
+            %i.fa.fa-gears.fa-fw
+          %ul.dropdown-menu.dropdown-menu-right.dropdown-scrolly{ role:"menu"}
+            %li.dropdown-header
+              Run Automation
+            - @automations.each do |automation|
+              %li= link_to(automation.form_attribute('name'), "#", data: {toggle: "run_automation_link", node_id: node.id, link: plugin('automation').run_automation_nodes_path(node_id: node.id, automation_id: automation.form_attribute('id'), automation_name: automation.form_attribute('name')) })
+
+      - if current_user.is_allowed?('automation:node_delete')
+        = link_to plugin('automation').node_path(id: node.id), class: 'btn btn-default btn-sm', :method => 'delete', data: { confirm: "Are you sure you want to remove the node #{node.name}?", ok: "Yes, remove it", confirmed: :loading_status} do
+          %i.fa.fa-trash.fa-fw

--- a/plugins/automation/app/views/automation/nodes/index.html.haml
+++ b/plugins/automation/app/views/automation/nodes/index.html.haml
@@ -17,9 +17,9 @@
           %a.help-link{href: "#", data: {toggle: "popover", "popover-type": "help-hint", content: 'Search by name tag, hostname or ID. To use the advanced search use the format “key=value”. Advanced search will find nodes with the given key and value from tags and facts.'}}
             %i.fa.fa-question-circle
 
-
-      .main-buttons
-        = link_to "Add Node", plugin('automation').install_nodes_path, data: {modal: true}, class: 'btn btn-primary'
+      - if current_user.is_allowed?('automation:node_install')
+        .main-buttons
+          = link_to "Add Node", plugin('automation').install_nodes_path, data: {modal: true}, class: 'btn btn-primary'
 
 
     .search-dimmed-area.js-search-dimmed-area

--- a/plugins/automation/app/views/automation/shared/_roles_atention_box.html.haml
+++ b/plugins/automation/app/views/automation/shared/_roles_atention_box.html.haml
@@ -1,25 +1,17 @@
 .bs-callout.bs-callout-info.bs-callout-emphasize
   %h4
-    Atention! Automation has introduced policy roles restriction
+    Please note:
   %p
     Two new roles,
     %code
       automation_admin
     and
-    %code
-      automation_viewer
-    , are available to manage the automation service.
+    <code>automation_viewer</code>, are available to manage the automation service. From now on you will need either role to be able to access automation.
   %ul
     %li
       %b automation_admin:
-      automation administrator in the project. Can perform any action in the automation service:
-
-      %ul
-        %li Add and remove Nodes
-        %li Update Node tags
-        %li Create, update and run Automations
-        %li List and show Nodes, Automations, Runs, Jobs and Logs
+      automation administrator in the project. Can perform any action in the automation service.
 
     %li
       %b automation_viewer:
-      automation read-only in the project. Can just list and show Nodes, Automations, Runs, Jobs and Logs.
+      automation read-only in the project. Can just list and show nodes, automations, runs, jobs and logs.

--- a/plugins/automation/app/views/automation/shared/_roles_atention_box.html.haml
+++ b/plugins/automation/app/views/automation/shared/_roles_atention_box.html.haml
@@ -1,0 +1,25 @@
+.bs-callout.bs-callout-info.bs-callout-emphasize
+  %h4
+    Atention! Automation has introduced policy roles restriction
+  %p
+    Two new roles,
+    %code
+      automation_admin
+    and
+    %code
+      automation_viewer
+    , are available to manage the automation service.
+  %ul
+    %li
+      %b automation_admin:
+      automation administrator in the project. Can perform any action in the automation service:
+
+      %ul
+        %li Add and remove Nodes
+        %li Update Node tags
+        %li Create, update and run Automations
+        %li List and show Nodes, Automations, Runs, Jobs and Logs
+
+    %li
+      %b automation_viewer:
+      automation read-only in the project. Can just list and show Nodes, Automations, Runs, Jobs and Logs.

--- a/plugins/automation/app/views/automation/shared/warning.html.haml
+++ b/plugins/automation/app/views/automation/shared/warning.html.haml
@@ -1,0 +1,46 @@
+- @header_title ||= "Application"
+- @title ||= "Warning"
+- @description ||= "Service unavailable"
+
+- if modal?
+  = content_for :title do
+    %span{class: "#{plugin_name}-icon warning-icon"}
+    %span.active
+      = "#{@header_title} Warning"
+
+  .modal-body
+    %h3= sanitize(@title)
+    %p= sanitize(@description, tags: %w(b))
+
+  .modal-footer
+    %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Close"}} Close
+
+- else
+  .bs-callout.bs-callout-info.bs-callout-emphasize
+    %h4
+      Warning! Automation has introduced policy roles restriction
+    %p
+      Two new roles,
+      %code
+        automation_admin
+      and
+      %code
+        automation_viewer
+      , are available to manage the automation service.
+    %ul
+      %li
+        %b automation_admin:
+        automation administrator in the project. Can perform any action in the automation service:
+
+        %ul
+          %li Add and remove Nodes
+          %li Update Node tags
+          %li Create, update and run Automations
+          %li List and show Nodes, Automations, Runs, Jobs and Logs
+
+      %li
+        %b automation_viewer:
+        automation read-only in the project. Can just list and show Nodes, Automations, Runs, Jobs and Logs.
+
+  %h3= sanitize(@title)
+  %p= sanitize(@description, tags: %w(b))

--- a/plugins/automation/app/views/automation/shared/warning.html.haml
+++ b/plugins/automation/app/views/automation/shared/warning.html.haml
@@ -9,6 +9,8 @@
       = "#{@header_title} Warning"
 
   .modal-body
+    = render partial: 'automation/shared/roles_atention_box'
+    
     %h3= sanitize(@title)
     %p= sanitize(@description, tags: %w(b))
 
@@ -16,31 +18,7 @@
     %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Close"}} Close
 
 - else
-  .bs-callout.bs-callout-info.bs-callout-emphasize
-    %h4
-      Warning! Automation has introduced policy roles restriction
-    %p
-      Two new roles,
-      %code
-        automation_admin
-      and
-      %code
-        automation_viewer
-      , are available to manage the automation service.
-    %ul
-      %li
-        %b automation_admin:
-        automation administrator in the project. Can perform any action in the automation service:
-
-        %ul
-          %li Add and remove Nodes
-          %li Update Node tags
-          %li Create, update and run Automations
-          %li List and show Nodes, Automations, Runs, Jobs and Logs
-
-      %li
-        %b automation_viewer:
-        automation read-only in the project. Can just list and show Nodes, Automations, Runs, Jobs and Logs.
+  = render partial: 'automation/shared/roles_atention_box'
 
   %h3= sanitize(@title)
   %p= sanitize(@description, tags: %w(b))

--- a/plugins/automation/config/policy.json
+++ b/plugins/automation/config/policy.json
@@ -16,6 +16,8 @@
   "automation:automation_create": "role:automation_admin",
   "automation:automation_get": "rule:automation_role_required",
   "automation:automation_update": "role:automation_admin",
-  "automation:automation_delete": "role:automation_admin"
+  "automation:automation_delete": "role:automation_admin",
 
+  "automation:run_get": "rule:automation_role_required",
+  "automation:run_show_log": "rule:automation_role_required"
 }

--- a/plugins/automation/config/policy.json
+++ b/plugins/automation/config/policy.json
@@ -1,3 +1,21 @@
 {
-  "automation:agent_index": "rule:admin_required"
+  "automation_role_required": "role:automation_admin or role:automation_viewer",
+  "automation:node_list": "rule:automation_role_required",
+  "automation:node_get": "rule:automation_role_required",
+  "automation:node_install": "role:automation_admin",
+  "automation:node_show_instructions": "role:automation_admin",
+  "automation:node_update": "role:automation_admin",
+  "automation:node_run_automation": "role:automation_admin",
+  "automation:node_delete": "role:automation_admin",
+
+  "automation:job_get": "rule:automation_role_required",
+  "automation:job_show_data": "rule:automation_role_required",
+
+  "automation:automation_list": "rule:automation_role_required",
+  "automation:automation_index_update_runs": "rule:automation_role_required",
+  "automation:automation_create": "role:automation_admin",
+  "automation:automation_get": "rule:automation_role_required",
+  "automation:automation_update": "role:automation_admin",
+  "automation:automation_delete": "role:automation_admin"
+
 }

--- a/plugins/automation/spec/controllers/automations_controller_spec.rb
+++ b/plugins/automation/spec/controllers/automations_controller_spec.rb
@@ -20,8 +20,6 @@ describe Automation::AutomationsController, type: :controller do
   end
 
   before :each do
-    stub_authentication
-
     client = double('arc_client').as_null_object
     @automation_service = double('automation_service').as_null_object
     automation_run_service = double('automation_run_service').as_null_object
@@ -34,142 +32,380 @@ describe Automation::AutomationsController, type: :controller do
   end
 
   describe "GET 'index'" do
-
-    it "returns http success" do
-      get :index, params: default_params
-      expect(response).to be_success
-      expect(response).to render_template(:index)
-    end
-
-    describe "@pag_params" do
-
-      it "should set up pagination object" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
         get :index, params: default_params
-        expect(assigns(:pag_params)).to eq({:automation=>{:page=>0}, :run=>{:page=>0}})
+        expect(response).to be_success
+        expect(response).to render_template(:index)
       end
-
-      it "should set the righ params when loading the page" do
-        get :index, params: default_params.merge(:pag_params => {:automation=>{:page=>"2"}, :run=>{:page=>"3"}})
-        expect(assigns(:pag_params)).to eq({:automation=>{:page=>"2"}, :run=>{:page=>"3"}})
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
       end
-
-      it "should updated just the run param when ajax" do
-        get :index, params: default_params.merge({:page => "5", :model => "run"}), xhr: true
-        expect(assigns(:pag_params)).to eq({:automation=>{:page=>0}, :run=>{:page=>"5"}})
+      it 'returns http success' do
+        get :index, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:index)
       end
-
-      it "should updated just the automation param when ajax" do
-        get :index, params: default_params.merge({:page => "5", :model => "automation"}), xhr: true
-        expect(assigns(:pag_params)).to eq({:automation=>{:page=>"5"}, :run=>{:page=>0}})
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
       end
-
+      it 'not allowed' do
+        get :index, params: default_params
+        expect(response).to_not be_success
+      end
     end
 
+    describe '@pag_params' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'should set up pagination object' do
+        get :index, params: default_params
+        expect(assigns(:pag_params)).to eq(automation: { page: 0 }, run: { page: 0 })
+      end
+
+      it 'should set the righ params when loading the page' do
+        get :index, params: default_params.merge(pag_params: { automation: { page: '2' }, run: { page: '3' } })
+        expect(assigns(:pag_params)).to eq(automation: { page: '2' }, run: { page: '3' })
+      end
+
+      it 'should updated just the run param when ajax' do
+        get :index, params: default_params.merge(page: '5', model: 'run'), xhr: true
+        expect(assigns(:pag_params)).to eq(automation: { page: 0 }, run: { page: '5' })
+      end
+
+      it 'should updated just the automation param when ajax' do
+        get :index, params: default_params.merge(page: '5', model: 'automation'), xhr: true
+        expect(assigns(:pag_params)).to eq(automation: { page: '5' }, run: { page: 0 })
+      end
+    end
   end
 
   describe "GET 'new'" do
-
-    it "returns http success" do
-      get :new, params: default_params
-      expect(response).to be_success
-      expect(response).to render_template(:new)
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :new, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:new)
+      end
     end
-
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'not allowed' do
+        get :new, params: default_params
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        get :new, params: default_params
+        expect(response).to_not be_success
+      end
+    end
   end
 
   describe "GET 'create'" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'redirect when automation valid' do
+        automation = ::Automation::FakeFactory.new.automation_form_chef
+        expect(post(:create, params: default_params.merge(forms_chef_automation: automation.attributes))).to redirect_to(automations_path(default_params))
+      end
 
-    it "redirect when automation valid" do
-      automation = ::Automation::FakeFactory.new.automation_form_chef
-      expect(post :create, params: default_params.merge({forms_chef_automation: automation.attributes})).to redirect_to(automations_path(default_params))
+      it 'return success and render new when automation invalid' do
+        post :create, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:new)
+        expect(flash.now[:error]).to_not be_nil
+      end
     end
-
-    it "return success and render new when automation invalid" do
-      post :create, params: default_params
-      expect(response).to be_success
-      expect(response).to render_template(:new)
-      expect(flash.now[:error]).to_not be_nil
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'not allowed' do
+        post :create, params: default_params
+        expect(response).to_not be_success
+      end
     end
-
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        post :create, params: default_params
+        expect(response).to_not be_success
+      end
+    end
   end
 
   describe "GET 'show'" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
 
-    it "returns http success" do
-      allow(@automation_service).to receive(:attributes_to_form).and_return({})
-
-      get :show, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template(:show)
+        get :show, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template(:show)
+      end
     end
-
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
+        get :show, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template(:show)
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
+        get :show, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
+    end
   end
 
   describe "GET 'edit'" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
 
-    it "returns http success" do
-      allow(@automation_service).to receive(:attributes_to_form).and_return({})
-
-      get :edit, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template(:edit)
+        get :edit, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template(:edit)
+      end
     end
-
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'not allowed' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
+        get :edit, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
+        get :edit, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
+    end
   end
 
   describe "GET 'update'" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'should return to the edit view with an error if type have been changed' do
+        automation = ::Automation::FakeFactory.new.automation_form_chef
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_return(automation)
 
-    it "should return to the edit view with an error if type have been changed" do
-      automation = ::Automation::FakeFactory.new.automation_form_chef
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_return(automation)
+        get :update, params: default_params.merge(id: 'automation_id', forms_chef_automation: automation.attributes.merge(type: 'other_type'))
+        expect(response).to be_success
+        expect(response).to render_template(:edit)
+        expect(flash.now[:error]).to_not be_nil
+      end
 
-      get :update, params: default_params.merge({id: 'automation_id', forms_chef_automation: automation.attributes.merge(type: 'other_type')})
-      expect(response).to be_success
-      expect(response).to render_template(:edit)
-      expect(flash.now[:error]).to_not be_nil
+      it 'returns http success and shows edit view when automation is invalid' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
+
+        get :update, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template(:edit)
+      end
+
+      it 'should redirect to the automations index view when update is successful' do
+        automation = ::Automation::FakeFactory.new.automation_form_chef
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_return(automation)
+
+        expect(get(:update, params: default_params.merge(id: 'automation_id', forms_chef_automation: automation.attributes))).to redirect_to(automations_path(default_params))
+      end
+
+      it 'something wrong happens show a flash error' do
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_raise('boom')
+        get :update, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template(:edit)
+        expect(flash.now[:error]).to_not be_nil
+      end
     end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'not allowed' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
 
-    it "returns http success and shows edit view when automation is invalid" do
-      allow(@automation_service).to receive(:attributes_to_form).and_return({})
-
-      get :update, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template(:edit)
+        get :update, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
     end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        allow(@automation_service).to receive(:attributes_to_form).and_return({})
 
-    it "should redirect to the automations index view when update is successful" do
-      automation = ::Automation::FakeFactory.new.automation_form_chef
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_return(automation)
-
-      expect(get :update, params: default_params.merge({id: 'automation_id', forms_chef_automation: automation.attributes})).to redirect_to(automations_path(default_params))
+        get :update, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
     end
-
-    it "something wrong happens show a flash error" do
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_raise("boom")
-      get :update, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template(:edit)
-      expect(flash.now[:error]).to_not be_nil
-    end
-
   end
 
   describe "GET 'destroy'" do
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success and renders view' do
+        delete :destroy, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template('automation/automations/update_item.js')
+      end
 
-    it "returns http success and renders view" do
-      delete :destroy, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template("automation/automations/update_item.js")
+      it 'something wrong happens show a flash error' do
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_raise('boom')
+        delete :destroy, params: default_params.merge(id: 'automation_id')
+        expect(response).to be_success
+        expect(response).to render_template('automation/automations/update_item.js')
+        expect(flash.now[:error]).to_not be_nil
+      end
     end
-
-    it "something wrong happens show a flash error" do
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:automation).and_raise("boom")
-      delete :destroy, params: default_params.merge({id: 'automation_id'})
-      expect(response).to be_success
-      expect(response).to render_template("automation/automations/update_item.js")
-      expect(flash.now[:error]).to_not be_nil
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'not allowed' do
+        delete :destroy, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
     end
-
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token
+        end
+      end
+      it 'not allowed' do
+        delete :destroy, params: default_params.merge(id: 'automation_id')
+        expect(response).to_not be_success
+      end
+    end
   end
-
 end

--- a/plugins/automation/spec/controllers/jobs_controller_spec.rb
+++ b/plugins/automation/spec/controllers/jobs_controller_spec.rb
@@ -76,7 +76,7 @@ describe Automation::JobsController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success and renders the right template' do
+      it 'not allowed' do
         get :show, params: default_params.merge(id: @job.id)
         expect(response).to_not be_success
       end
@@ -144,12 +144,12 @@ describe Automation::JobsController, type: :controller do
             token['roles'].delete_if { |h| h['id'] == 'automation_role' }
           end
         end
-        it 'returns http success and render the template for payload' do
+        it 'not allowed for payload' do
           get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
           expect(response).to_not be_success
         end
 
-        it 'returns http success and render the template for log' do
+        it 'not allowed for log' do
           get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
           expect(response).to_not be_success
         end
@@ -216,12 +216,12 @@ describe Automation::JobsController, type: :controller do
             token['roles'].delete_if { |h| h['id'] == 'automation_role' }
           end
         end
-        it 'returns http success and render the template for payload' do
+        it 'not allowed for payload' do
           get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
           expect(response).to_not be_success
         end
 
-        it 'returns http success and render the template for log' do
+        it 'not allowed for log' do
           get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
           expect(response).to_not be_success
         end

--- a/plugins/automation/spec/controllers/jobs_controller_spec.rb
+++ b/plugins/automation/spec/controllers/jobs_controller_spec.rb
@@ -6,16 +6,14 @@ require_relative '../factories/factories'
 describe Automation::JobsController, type: :controller do
   routes { Automation::Engine.routes }
 
-  default_params = {domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id}
+  default_params = { domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id }
 
   before(:all) do
-    FriendlyIdEntry.find_or_create_entry('Domain',nil,default_params[:domain_id],'default')
-    FriendlyIdEntry.find_or_create_entry('Project',default_params[:domain_id],default_params[:project_id],default_params[:project_id])
+    FriendlyIdEntry.find_or_create_entry('Domain', nil, default_params[:domain_id], 'default')
+    FriendlyIdEntry.find_or_create_entry('Project', default_params[:domain_id], default_params[:project_id], default_params[:project_id])
   end
 
   before :each do
-    stub_authentication
-
     client = double('arc_client').as_null_object
     automation_service = double('automation_service').as_null_object
     automation_run_service = double('automation_run_service').as_null_object
@@ -28,7 +26,6 @@ describe Automation::JobsController, type: :controller do
   end
 
   describe "GET 'show'" do
-
     before :each do
       @job = ::Automation::FakeFactory.new.job
       @payload = @job.payload
@@ -39,22 +36,54 @@ describe Automation::JobsController, type: :controller do
       allow_any_instance_of(ServiceLayer::AutomationService).to receive(:job_log).with(@job.id).and_return(@log)
     end
 
-    it "returns http success and renders the right template" do
-      get :show, params: default_params.merge({id: @job.id})
-      expect(response).to be_success
-      expect(response).to render_template(:show)
-    end
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success and renders the right template' do
+        get :show, params: default_params.merge(id: @job.id)
+        expect(response).to be_success
+        expect(response).to render_template(:show)
+      end
 
-    it "should assign the log and payload" do
-      get :show, params: default_params.merge({id: @job.id})
-      expect(@log).to include(assigns(:truncated_log).data_output)
-      expect(@payload).to include(assigns(:truncated_payload).data_output)
+      it 'should assign the log and payload' do
+        get :show, params: default_params.merge(id: @job.id)
+        expect(@log).to include(assigns(:truncated_log).data_output)
+        expect(@payload).to include(assigns(:truncated_payload).data_output)
+      end
     end
-
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success and renders the right template' do
+        get :show, params: default_params.merge(id: @job.id)
+        expect(response).to be_success
+        expect(response).to render_template(:show)
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success and renders the right template' do
+        get :show, params: default_params.merge(id: @job.id)
+        expect(response).to_not be_success
+      end
+    end
   end
 
   describe "GET 'show_data'" do
-
     context 'plain text' do
       before :each do
         @job = ::Automation::FakeFactory.new.job
@@ -65,24 +94,71 @@ describe Automation::JobsController, type: :controller do
         allow_any_instance_of(ServiceLayer::AutomationService).to receive(:job_log).with(@job.id).and_return(@log)
       end
 
-      it "returns http success and render the template for payload" do
-        get :show_data, params: default_params.merge({id: @job.id, attr: 'payload'})
-        expect(response).to be_success
-        expect(response).to render_template(:show_data)
-        expect(assigns(:data)).to eq(@payload)
-      end
+      context 'automation_admin' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+            token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+            token
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(@payload)
+        end
 
-      it "returns http success and render the template for log" do
-        get :show_data, params: default_params.merge({id: @job.id, attr: 'log'})
-        expect(response).to be_success
-        expect(response).to render_template(:show_data)
-        expect(assigns(:data)).to eq(@log)
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(@log)
+        end
+      end
+      context 'automation_viewer' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+            token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+            token
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(@payload)
+        end
+
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(@log)
+        end
+      end
+      context 'other roles' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to_not be_success
+        end
+
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to_not be_success
+        end
       end
     end
 
     context 'json' do
       before :each do
-        @job = ::Automation::FakeFactory.new.job({payload: '{"run_list": ["role[landscape]","recipe[ids::certificate]"]}'})
+        @job = ::Automation::FakeFactory.new.job(payload: '{"run_list": ["role[landscape]","recipe[ids::certificate]"]}')
         @payload = @job.payload
         @log = '{"test": ["miau","bup", "kuack"]}'
 
@@ -90,21 +166,66 @@ describe Automation::JobsController, type: :controller do
         allow_any_instance_of(ServiceLayer::AutomationService).to receive(:job_log).with(@job.id).and_return(@log)
       end
 
-      it "returns http success and render the template for payload" do
-        get :show_data, params: default_params.merge({id: @job.id, attr: 'payload'})
-        expect(response).to be_success
-        expect(response).to render_template(:show_data)
-        expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@payload)))
-      end
+      context 'automation_admin' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+            token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+            token
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@payload)))
+        end
 
-      it "returns http success and render the template for log" do
-        get :show_data, params: default_params.merge({id: @job.id, attr: 'log'})
-        expect(response).to be_success
-        expect(response).to render_template(:show_data)
-        expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@log)))
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@log)))
+        end
+      end
+      context 'automation_viewer' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+            token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+            token
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@payload)))
+        end
+
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to be_success
+          expect(response).to render_template(:show_data)
+          expect(assigns(:data)).to eq(JSON.pretty_generate(JSON.parse(@log)))
+        end
+      end
+      context 'other roles' do
+        before :each do
+          stub_authentication do |token|
+            token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          end
+        end
+        it 'returns http success and render the template for payload' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'payload')
+          expect(response).to_not be_success
+        end
+
+        it 'returns http success and render the template for log' do
+          get :show_data, params: default_params.merge(id: @job.id, attr: 'log')
+          expect(response).to_not be_success
+        end
       end
     end
-
   end
-
 end

--- a/plugins/automation/spec/controllers/nodes_controller_spec.rb
+++ b/plugins/automation/spec/controllers/nodes_controller_spec.rb
@@ -78,7 +78,7 @@ describe Automation::NodesController, type: :controller do
         end
       end
 
-      it 'returns http success' do
+      it 'not allowed' do
         get :index, params: default_params
         expect(response).to_not be_success
       end
@@ -132,7 +132,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :show, params: default_params.merge(id: 'node_id')
         expect(response).to_not be_success
       end
@@ -177,7 +177,7 @@ describe Automation::NodesController, type: :controller do
           token
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :install, params: default_params
         expect(response).to_not be_success
       end
@@ -188,7 +188,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :install, params: default_params
         expect(response).to_not be_success
       end
@@ -218,7 +218,7 @@ describe Automation::NodesController, type: :controller do
           token
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
         expect(response).to_not be_success
       end
@@ -229,7 +229,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
         expect(response).to_not be_success
       end
@@ -268,7 +268,7 @@ describe Automation::NodesController, type: :controller do
           token
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         put :update, params: default_params.merge(id: 'node_id'), xhr: true
         expect(response).to_not be_success
       end
@@ -279,7 +279,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         put :update, params: default_params.merge(id: 'node_id'), xhr: true
         expect(response).to_not be_success
       end
@@ -317,7 +317,7 @@ describe Automation::NodesController, type: :controller do
           token
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
         expect(response).to_not be_success
       end
@@ -328,7 +328,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
         expect(response).to_not be_success
       end
@@ -356,7 +356,7 @@ describe Automation::NodesController, type: :controller do
           token
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to_not be_success
       end
     end
@@ -366,7 +366,7 @@ describe Automation::NodesController, type: :controller do
           token['roles'].delete_if { |h| h['id'] == 'automation_role' }
         end
       end
-      it 'returns http success' do
+      it 'not allowed' do
         expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to_not be_success
       end
     end

--- a/plugins/automation/spec/controllers/nodes_controller_spec.rb
+++ b/plugins/automation/spec/controllers/nodes_controller_spec.rb
@@ -14,8 +14,6 @@ describe Automation::NodesController, type: :controller do
   end
 
   before :each do
-    stub_authentication
-
     client = double('arc_client').as_null_object
     automation_service = double('automation_service').as_null_object
     automation_run_service = double('automation_run_service').as_null_object
@@ -37,36 +35,107 @@ describe Automation::NodesController, type: :controller do
       allow(IndexNodesService).to receive(:new).and_return(indexServiceNode)
     end
 
-    it 'returns http success' do
-      get :index, params: default_params
-      expect(response).to be_success
-      expect(response).to render_template(:index)
-    end
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
 
-    it 'should assign variables' do
-      get :index, params: default_params
-      expect(@nodes[:elements]).to eq(assigns(:nodes))
-      expect(@nodes[:jobs]).to include(assigns(:jobs))
+      it 'returns http success' do
+        get :index, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:index)
+      end
+
+      it 'should assign variables' do
+        get :index, params: default_params
+        expect(@nodes[:elements]).to eq(assigns(:nodes))
+        expect(@nodes[:jobs]).to include(assigns(:jobs))
+      end
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+
+      it 'returns http success' do
+        get :index, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:index)
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+
+      it 'returns http success' do
+        get :index, params: default_params
+        expect(response).to_not be_success
+      end
     end
   end
 
   describe "GET 'show'" do
-    it 'returns http success' do
-      get :show, params: default_params.merge(id: 'node_id')
-      expect(response).to be_success
-      expect(response).to render_template(:show)
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+
+      it 'returns http success' do
+        get :show, params: default_params.merge(id: 'node_id')
+        expect(response).to be_success
+        expect(response).to render_template(:show)
+      end
+
+      it 'should assign variables' do
+        node = ::Automation::FakeFactory.new.node
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:node).and_return(node)
+
+        get :show, params: default_params.merge(id: 'node_id')
+        expect(node).to eq(assigns(:node))
+        expect(assigns(:node_form)).to be_truthy
+        expect(assigns(:node_form_read)).to be_truthy
+        expect(assigns(:facts)).to be_truthy
+        expect(assigns(:jobs)).to be_truthy
+      end
     end
-
-    it 'should assign variables' do
-      node = ::Automation::FakeFactory.new.node
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:node).and_return(node)
-
-      get :show, params: default_params.merge(id: 'node_id')
-      expect(node).to eq(assigns(:node))
-      expect(assigns(:node_form)).to be_truthy
-      expect(assigns(:node_form_read)).to be_truthy
-      expect(assigns(:facts)).to be_truthy
-      expect(assigns(:jobs)).to be_truthy
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :show, params: default_params.merge(id: 'node_id')
+        expect(response).to be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        get :show, params: default_params.merge(id: 'node_id')
+        expect(response).to_not be_success
+      end
     end
   end
 
@@ -75,68 +144,231 @@ describe Automation::NodesController, type: :controller do
       allow_any_instance_of(ServiceLayer::ComputeService).to receive(:servers).and_raise('boom')
     end
 
-    it 'returns http success' do
-      get :install, params: default_params
-      expect(response).to be_success
-      expect(response).to render_template(:install)
-    end
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :install, params: default_params
+        expect(response).to be_success
+        expect(response).to render_template(:install)
+      end
 
-    it 'should assign variables' do
-      get :install, params: default_params
-      expect(assigns(:compute_instances)).to be_truthy
-    end
+      it 'should assign variables' do
+        get :install, params: default_params
+        expect(assigns(:compute_instances)).to be_truthy
+      end
 
-    it 'should rescue on error' do
-      get :install, params: default_params
-      expect(assigns(:compute_instances)).to be_empty
-      expect(assigns(:errors)).to be_truthy
+      it 'should rescue on error' do
+        get :install, params: default_params
+        expect(assigns(:compute_instances)).to be_empty
+        expect(assigns(:errors)).to be_truthy
+      end
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :install, params: default_params
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        get :install, params: default_params
+        expect(response).to_not be_success
+      end
     end
   end
 
   describe "GET xhr 'show_instructions'" do
-    it 'returns http success' do
-      get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
-      expect(response).to be_success
-      expect(response).to render_template(:show_instructions)
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
+        expect(response).to be_success
+        expect(response).to render_template(:show_instructions)
+      end
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        get :show_instructions, params: default_params.merge(id: 'instance_id', type: 'external'), xhr: true
+        expect(response).to_not be_success
+      end
     end
   end
 
   describe "GET xhr 'update'" do
-    it 'returns http success' do
-      put :update, params: default_params.merge(id: 'node_id'), xhr: true
-      expect(response).to be_success
-      expect(response).to render_template(:update)
-    end
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        put :update, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to be_success
+        expect(response).to render_template(:update)
+      end
 
-    it 'renders the page correcty when an exception happens' do
-      allow_any_instance_of(Automation::Forms::NodeTags).to receive(:update).and_raise('boom update')
-      put :update, params: default_params.merge(id: 'node_id'), xhr: true
-      expect(assigns(:node)).to be_truthy
-      expect(assigns(:node_form_read)).to be_truthy
-      expect(assigns(:node_form)).to be_truthy
-      # expect(assigns(:errors)).to be_truthy
+      it 'renders the page correcty when an exception happens' do
+        allow_any_instance_of(Automation::Forms::NodeTags).to receive(:update).and_raise('boom update')
+        put :update, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(assigns(:node)).to be_truthy
+        expect(assigns(:node_form_read)).to be_truthy
+        expect(assigns(:node_form)).to be_truthy
+        # expect(assigns(:errors)).to be_truthy
+      end
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        put :update, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        put :update, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to_not be_success
+      end
     end
   end
 
   describe 'GET xhr run_automation' do
-    it 'returns http success' do
-      get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
-      expect(response).to be_success
-      expect(response).to render_template(:run_automation)
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to be_success
+        expect(response).to render_template(:run_automation)
+      end
+      it 'returns a warning if the node is offline' do
+        node = ::Automation::FakeFactory.new.node
+        node.facts[:online] = false
+        allow_any_instance_of(ServiceLayer::AutomationService).to receive(:node).and_return(node)
+        get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to be_success
+        expect(flash.now[:warning]).to_not be_nil
+      end
     end
-    it 'returns a warning if the node is offline' do
-      node = ::Automation::FakeFactory.new.node
-      node.facts[:online] = false
-      allow_any_instance_of(ServiceLayer::AutomationService).to receive(:node).and_return(node)
-      get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
-      expect(response).to be_success
-      expect(flash.now[:warning]).to_not be_nil
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        get :run_automation, params: default_params.merge(id: 'node_id'), xhr: true
+        expect(response).to_not be_success
+      end
     end
   end
 
   describe 'DELETE destroy' do
-    it 'returns http success' do
-      expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to redirect_to(nodes_path(default_params))
+    context 'automation_admin' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_admin' }
+          token
+        end
+      end
+      it 'returns http success' do
+        expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to redirect_to(nodes_path(default_params))
+      end
+    end
+    context 'automation_viewer' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+          token['roles'] << { 'id' => 'automation_role', 'name' => 'automation_viewer' }
+          token
+        end
+      end
+      it 'returns http success' do
+        expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to_not be_success
+      end
+    end
+    context 'other roles' do
+      before :each do
+        stub_authentication do |token|
+          token['roles'].delete_if { |h| h['id'] == 'automation_role' }
+        end
+      end
+      it 'returns http success' do
+        expect(delete(:destroy, params: default_params.merge(id: 'node_id'))).to_not be_success
+      end
     end
   end
 end

--- a/plugins/compute/app/views/compute/instances/_cloud_init_menu.html.haml
+++ b/plugins/compute/app/views/compute/instances/_cloud_init_menu.html.haml
@@ -1,6 +1,15 @@
 .toolbar.toolbar-aligntop
   .main-buttons
-    = link_to "#", class: 'btn btn-default btn-xs', data: {toggle: 'automationBootstrap', automation_script_action: @automation_script_action} do
-      %i.fa.fa-plus.fa-fw
-      %i.loading-spinner-button.hide
-      Automation
+
+    - if current_user.is_allowed?('compute:instance_automation_script')
+      = link_to "#", class: 'btn btn-default btn-xs', data: {toggle: 'automationBootstrap', automation_script_action: @automation_script_action} do
+        %i.fa.fa-plus.fa-fw
+        %i.loading-spinner-button.hide
+        Automation
+    - else
+      = link_to "javascript:void(0)", class: 'btn btn-default btn-xs', :disabled => true do
+        %i.fa.fa-plus.fa-fw
+        %i.loading-spinner-button.hide
+        Automation
+      %a.help-link.has-feedback-help{href: "#", data: {toggle: "popover", "popover-type": "help-hint", content: 'You are not authorized. Please check (role assignments) if you have one of the following roles: automation_admin.'}}
+        %i.fa.fa-question-circle

--- a/plugins/compute/config/policy.json
+++ b/plugins/compute/config/policy.json
@@ -26,6 +26,8 @@
   "compute:instance_revert_resize": "rule:instance_actions",
   "compute:instance_lock": "rule:context_is_compute_admin",
   "compute:instance_unlock": "rule:context_is_compute_admin",
+  "compute:instance_automation_script": "role:automation_admin",
+  "compute:instance_automation_data": "role:automation_admin",
   "compute:instance_update": "rule:instance_actions",
   "compute:instance_reset_status": "rule:context_is_compute_admin",
   "compute:instance_edit_securitygroups": "rule:context_is_compute_admin or rule:context_is_network_admin",

--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -1,4 +1,4 @@
-ALLOWED_ROLES = %w(
+ALLOWED_ROLES = %w[
   admin
   audit_viewer
   compute_admin
@@ -20,7 +20,7 @@ ALLOWED_ROLES = %w(
   swiftoperator
   volume_admin
   volume_viewer
-).freeze
+].freeze
 
-BETA_ROLES = %w(
-).freeze
+BETA_ROLES = %w[
+].freeze

--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -1,6 +1,8 @@
 ALLOWED_ROLES = %w[
   admin
   audit_viewer
+  automation_admin
+  automation_viewer
   compute_admin
   compute_viewer
   dns_viewer

--- a/plugins/metrics/spec/controllers/application_controller_spec.rb
+++ b/plugins/metrics/spec/controllers/application_controller_spec.rb
@@ -23,7 +23,7 @@ describe Metrics::ApplicationController, type: :controller do
 
   describe 'GET index' do
     it 'returns http success' do
-      get :index
+      get :index, params: default_params
       expect(response).to be_success
     end
   end

--- a/plugins/resource_management/spec/controllers/application_controller_spec.rb
+++ b/plugins/resource_management/spec/controllers/application_controller_spec.rb
@@ -3,23 +3,27 @@ require 'spec_helper'
 describe ResourceManagement::DomainAdminController, type: :controller do
   routes { ResourceManagement::Engine.routes }
 
-  default_params = {domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id}
+  default_params = { domain_id: AuthenticationStub.domain_id, project_id: AuthenticationStub.project_id }
 
   before(:all) do
-    FriendlyIdEntry.find_or_create_entry('Domain',nil,default_params[:domain_id],'default')
-    FriendlyIdEntry.find_or_create_entry('Project',default_params[:domain_id],default_params[:project_id],default_params[:project_id])
+    FriendlyIdEntry.find_or_create_entry('Domain', nil, default_params[:domain_id], 'default')
+    FriendlyIdEntry.find_or_create_entry('Project', default_params[:domain_id], default_params[:project_id], default_params[:project_id])
   end
 
   before :each do
     stub_authentication do |token|
       # domain admin
-      token["roles"] << {"id"=>"2", "name"=>"admin"}
-      token["domain"] = {"id"=>"1", "name"=>"test"}
+      token['roles'] << { 'id' => '2', 'name' => 'admin' }
+      token['roles'] << { 'id' => 'resource_role', 'name' => 'resource_viewer' }
+      token['domain'] = { 'id' => '1', 'name' => 'default' }
+      token
     end
+    allow_any_instance_of(ServiceLayer::ResourceManagementService)
+      .to receive(:find_domain).and_return(double('domain').as_null_object)
   end
 
   describe "GET 'index'" do
-    it "returns http success" do
+    it 'returns http success' do
       get :index, params: default_params
       expect(response).to be_success
     end


### PR DESCRIPTION
Automation plugin should implement a policy and repect the roles automation_admin & automation_viewer. Currently the user requires keystone admin and or members to setup and run automations.

Fixes #382