### PR TITLE
Allow unscoped search for cloud_support_tools_viewer

### DIFF
--- a/app/controllers/cache_controller.rb
+++ b/app/controllers/cache_controller.rb
@@ -230,7 +230,7 @@ class CacheController < ::ScopeController
   protected
 
   def where_current_token_scope(scope)
-    return scope if current_user.is_allowed?('cloud_admin')
+    return scope if current_user.is_allowed?('cloud_admin_or_support')
 
     if current_user.project_id && params[:type] == 'project'
       scope = scope.where(id: current_user.project_id)

--- a/config/policy.json
+++ b/config/policy.json
@@ -1,21 +1,24 @@
 {
   "project_parent": "not %(target.project.parent_id)s==nil",
   "monsoon2_domain": "%(target.scoped_domain_name)s=='monsoon2'",
-  
-  
+
+
   "admin_required": " role:admin or is_admin:1",
 
   "cloud_admin": "rule:admin_required and (token.is_admin_project:True or domain_id:'ccadmin')",
   "domain_admin": "rule:admin_required and not domain_id:nil",
   "project_admin": "rule:admin_required and not project_id:nil",
-  
+  "cloud_admin_or_support": "rule:cloud_admin or role:cloud_support_tools_viewer",
+  "cloud_support": "role:cloud_support_tools_viewer",
+
+
   "default": "rule:admin_required",
-  
+
   "service_role": "role:service",
   "service_or_admin": "rule:admin_required or rule:service_role",
   "owner": "user_id:%(user_id)s",
   "admin_or_owner": "rule:admin_required or rule:owner",
   "token_subject": "user_id:%(target.token.user_id)s",
   "admin_or_token_subject": "rule:admin_required or rule:token_subject",
-  "can_write": "(not domain_name:'monsoon2')" 
+  "can_write": "(not domain_name:'monsoon2')"
 }


### PR DESCRIPTION
Fixes #397 Allow unscoped (region-wide) search for cloud_support_tools_viewer role in addition to cloud_admin