### PR TITLE
Use 'Accept-Charset' header to define the charset. RFC https://tools.…

### DIFF
--- a/app/javascript/ajax_helper.js
+++ b/app/javascript/ajax_helper.js
@@ -67,7 +67,8 @@ export const createAjaxHelper = (options = {}) => {
   // console.log('instanceOptions',instanceOptions)
   const axiosInstance = axios.create(instanceOptions)
   // overwrite default Accept Header to use json only
-  axiosInstance.defaults.headers.common['Accept'] = 'application/json; charset=utf-8';
+  axiosInstance.defaults.headers.common['Accept'] = 'application/json';
+  axiosInstance.defaults.headers.common['Accept-Charset'] = 'utf-8';
 
   // use request interceptor to merge globalOptions.
   // The global options are available only after the entire JS


### PR DESCRIPTION
…ietf.org/html/rfc7231#section-5.3.3

According to RFC7231 the charset (for Accept) should be specified in the Accept-Charset header.
Desigate@Rocky uses latest pecan version which complies to this RFC and therefore will reply HTTP 406 in case the Accept header was specified as: 'application/json; charset=utf-8'.

For example:

curl -v -X GET -H "Accept: application/json; charset=utf-8" -H "X-Auth-Token: $OS_AUTH_TOKEN" https://dns-3.qa-de-1.xxx/v2/zones/......

< HTTP/1.1 406 Not Acceptable
< Server: nginx/1.15.3
< 
406 Not Acceptable

The resource could not be generated that was acceptable to your browser (content of type application/json; charset=utf-8. 

Previously, with older versions that used to work, but not anymore.

Please review, thanks!