### PR TITLE
Fix ap-jp-1 and ap-jp-2 geodata

### DIFF
--- a/app/assets/javascripts/regions.json
+++ b/app/assets/javascripts/regions.json
@@ -111,8 +111,8 @@
     "country":    "Japan",
     "regionkey":  "ap-jp-1",
     "regionname": "AP-JP-1",
-    "lat":        34.68,
-    "lon":        135.50,
+    "lat":        35.66,
+    "lon":        139.77,
     "available":  true,
     "date":       "2017"
   },
@@ -120,8 +120,8 @@
     "country":    "Japan",
     "regionkey":  "ap-jp-2",
     "regionname": "AP-JP-2",
-    "lat":        35.66,
-    "lon":        139.77,
+    "lat":        34.68,
+    "lon":        135.50,
     "available":  true,
     "date":       "2018"
   },


### PR DESCRIPTION
ap-jp-1 is located in Toyko, ap-jp-2 in Osaka but geodata for these
region said it was the other way around.