### PR TITLE
added generic remote console support

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -57,9 +57,9 @@ module Compute
       @instance = services.compute.find_server(params[:id])
       hypervisor = @instance.attributes['OS-EXT-SRV-ATTR:host'] || ''
       if hypervisor == 'nova-compute-ironic'
-        @console = services.compute.shellinabox_console(params[:id])
+        @console = services.compute.remote_console(params[:id], "serial", "shellinabox")
       else
-        @console = services.compute.vnc_console(params[:id])
+        @console = services.compute.remote_console(params[:id])
       end
       respond_to do |format|
         format.html { render action: :console, layout: 'compute/console'}

--- a/plugins/compute/app/models/compute/remote_console.rb
+++ b/plugins/compute/app/models/compute/remote_console.rb
@@ -2,6 +2,6 @@
 
 module Compute
   # Represents the Server Console
-  class VncConsole < Core::ServiceLayer::Model
+  class RemoteConsole < Core::ServiceLayer::Model
   end
 end

--- a/plugins/compute/app/models/compute/shellinabox_console.rb
+++ b/plugins/compute/app/models/compute/shellinabox_console.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Compute
-  # Represents the Server Console
-  class ShellinaboxConsole < Core::ServiceLayer::Model
-  end
-end

--- a/plugins/compute/app/services/service_layer/compute_service.rb
+++ b/plugins/compute/app/services/service_layer/compute_service.rb
@@ -15,12 +15,18 @@ module ServiceLayer
     include ComputeServices::Volume
     include ComputeServices::OsServerGroup
 
+    MICROVERSION = '2.60'
+
     def available?(_action_name_sym = nil)
       elektron.service?('compute')
     end
 
     def elektron_compute
-      @elektron_identity ||= elektron.service('compute', http_client: { read_timeout: 180 })
+      @elektron_identity ||= elektron.service(
+        'compute', 
+        http_client: { read_timeout: 180 },
+        headers: { 'X-OpenStack-Nova-API-Version' => MICROVERSION }
+      )
     end
 
     def usage(filter = {})

--- a/plugins/compute/app/services/service_layer/compute_services/server.rb
+++ b/plugins/compute/app/services/service_layer/compute_services/server.rb
@@ -60,33 +60,13 @@ module ServiceLayer
         nil
       end
 
-      def vnc_console(server_id, console_type = 'novnc')
-        response = elektron_compute.post("servers/#{server_id}/action") do
-          { 'os-getVNCConsole': { 'type': console_type } }
+      def remote_console(server_id, console_protocol = 'mks', console_type = 'webmks')
+        response = elektron_compute.post("servers/#{server_id}/remote-consoles") do
+          { 'remote_console': { 'protocol': console_protocol, 'type': console_type } }
         end
 
-        response.map_to('body.console') do |data|
-          Compute::VncConsole.new(self, data)
-        end
-
-        # TODO: since 2.5 remote-console should be available but for
-        # some reason it is not working
-        #       got a 404 not available
-        # api.compute.create_remote_console(
-        #  id,
-        #  "remote_console" => {
-        #    'protocol'=>'vnc',
-        #    'type' => console_type
-        # }
-      end
-
-      def shellinabox_console(server_id, console_type = 'shellinabox')
-        response = elektron_compute.post("servers/#{server_id}/action") do
-          { 'os-getSerialConsole': { 'type': console_type } }
-        end
-
-        response.map_to('body.console') do |data|
-          Compute::ShellinaboxConsole.new(self, data)
+        response.map_to('body.remote_console') do |data|
+          Compute::RemoteConsole.new(self, data)
         end
       end
 


### PR DESCRIPTION
This PR will implement the new remote console api:
https://developer.openstack.org/api-ref/compute/?expanded=show-console-output-os-getconsoleoutput-action-detail,get-vnc-console-os-getvncconsole-action-deprecated-detail#create-remote-console

and also unify shellinabox/vnc console to generic "remote_console" function.
Also enabled MKS by default, please wait a week before rollout to ensure mks is everywhere enabled.