### PR TITLE
added support for serial console log of nova

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -78,6 +78,8 @@ module Compute
           tenant_id: @scoped_project_id, id: sg.id
         ).first
       end.values
+
+      @log = services.compute.console_log(params[:id])
     end
 
     def new

--- a/plugins/compute/app/services/service_layer/compute_services/server.rb
+++ b/plugins/compute/app/services/service_layer/compute_services/server.rb
@@ -90,6 +90,14 @@ module ServiceLayer
         end
       end
 
+      def console_log(server_id, length=500)
+        response = elektron_compute.post("servers/#{server_id}/action") do
+          { 'os-getConsoleOutput': { 'length': length } }
+        end
+        
+        response.map_to('body.output')
+      end
+
       def rebuild_server(server_id, image_ref, name, admin_pass = nil,
                          metadata = nil, personality = nil)
         # prepare data

--- a/plugins/compute/app/views/compute/instances/show.html.haml
+++ b/plugins/compute/app/views/compute/instances/show.html.haml
@@ -11,6 +11,7 @@
     %ul.nav.nav-tabs
       %li.active{role: "presentation"}= link_to 'Information', '#information', aria: {controls:"information"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Specs', '#specs', aria: {controls:"specs"}, role: "tab", data: {toggle:"tab"}
+      %li{role: "presentation"}= link_to 'Serial Console', '#serial', aria: {controls:"serial"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'IP Addresses', '#ip_addresses', aria: {controls:"ip_addresses"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Security Groups', '#sec_groups', aria: {controls:"security_groups"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Key Pairs', '#keypairs', aria: {controls:"keypairs"}, role: "tab", data: {toggle:"tab"}
@@ -52,6 +53,11 @@
                   - project_id_and_name(@instance.tenant_id)
                 - else
                   = project_name(@instance.tenant_id)
+      
+      .tab-pane{role:"tabpanel", id:"serial"}
+        .pre-scrollable
+          %pre
+            %code= @log
 
       .tab-pane{role:"tabpanel", id:"specs"}
         - if @instance.flavor_object


### PR DESCRIPTION
this adds support for for getconsoleoutput api of nova:
https://developer.openstack.org/api-ref/compute/?expanded=show-console-output-os-getconsoleoutput-action-detail,get-vnc-console-os-getvncconsole-action-deprecated-detail#show-console-output-os-getconsoleoutput-action

Please feel free to improve it (like download the data only if clicked on "serial-log" or some kind of syntax highlighting ^^

![screenshot 2019-01-10 at 15 56 32](https://user-images.githubusercontent.com/2862494/50976627-c321f580-14f0-11e9-904b-476c508521c7.png)
