### PR TITLE
object store: inline content only for text/*

### DIFF
--- a/plugins/object_storage/app/views/object_storage/application/_object_list_entry.html.haml
+++ b/plugins/object_storage/app/views/object_storage/application/_object_list_entry.html.haml
@@ -6,13 +6,12 @@
       %span.fa.fa-fw.fa-folder-open{ title: 'Directory' }
       = link_to object.basename, plugin('object_storage').list_objects_path(encoded_container_name, encoded_object_path), title: 'List contents'
     - else
-      - if object.content_type.start_with?('image/')
-        %span.fa.fa-fw.fa-file-image-o{ title: 'Object' }
-      - elsif object.content_type.start_with?('text/')
+      - if object.content_type.start_with?('text/')
         %span.fa.fa-fw.fa-file-text-o{ title: 'Object' }
+        = link_to object.basename, plugin('object_storage').download_object_path(encoded_container_name, encoded_object_path, inline: 1), title: 'Show file contents in browser'
       - else
         %span.fa.fa-fw.fa-file-o{ title: 'Object' }
-      = link_to object.basename, plugin('object_storage').download_object_path(encoded_container_name, encoded_object_path, inline: 1), title: 'Show file contents in browser'
+        = link_to object.basename, plugin('object_storage').download_object_path(encoded_container_name, encoded_object_path), title: 'Download Object'
   %td
     - unless object.is_directory?
       = format_bytes(object.size_bytes)


### PR DESCRIPTION
As inline rendering of content is now html encoded, only Content-Types
of type `text/*` should be handled so. Otherwise Content Disposition is Download.