### PR TITLE
collect pagination data once with 0,5 sec delay when checking completed

### DIFF
--- a/app/assets/javascripts/jquery.ajax_paginate.coffee
+++ b/app/assets/javascripts/jquery.ajax_paginate.coffee
@@ -99,18 +99,17 @@ jQuery.fn.ajaxPaginate= ( options ) ->
             if $container.data('completed')
               hideLoading() unless loading
             else
-              loadAllOnSearch()
+              setTimeout(loadAllOnSearch,500)
         else
           hideLoading() unless loading
 
 
+      # get all entries once
       $(searchInputSelector).keyup (e) ->
-        clearTimeout(timer) if timer
-        timer = setTimeout(loadAllOnSearch,200)
-
-      $(searchInputSelector).keyup (e) ->
-        clearTimeout(timer) if timer
-        timer = setTimeout(loadAllOnSearch,1000)
+        unless loadAllMode
+          loadAllMode = true
+          clearTimeout(timer) if timer
+          loadAllOnSearch()
 
 
     # add load next items button


### PR DESCRIPTION
The pagination fetcher triggered by the search field had following issue "Maximum call stack size exceeded" coming from the application.js file. This is due that the loadAllOnSearch is being called continuously until end of stack. With a delay and triggering the fetcher once fix the problem.