### PR TITLE
fix remote console (shellinabox) detection for new ironic conductors

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -56,7 +56,7 @@ module Compute
     def console
       @instance = services.compute.find_server(params[:id])
       hypervisor = @instance.attributes['OS-EXT-SRV-ATTR:host'] || ''
-      if hypervisor == 'nova-compute-ironic'
+      if hypervisor.to_s.include?('nova-compute-ironic')
         @console = services.compute.remote_console(params[:id], "serial", "shellinabox")
       else
         @console = services.compute.remote_console(params[:id])


### PR DESCRIPTION
should fix remote console problems with baremetal servers since the compute-nodes are called "nova-compute-ironic-bbXX"