### PR TITLE
extended cname check for mx

### DIFF
--- a/plugins/dns_service/app/models/dns_service/recordset.rb
+++ b/plugins/dns_service/app/models/dns_service/recordset.rb
@@ -3,7 +3,7 @@
 module DnsService
   # represents the openstack dns recordset
   class Recordset < Core::ServiceLayer::Model
-    validate :is_cname
+    validate :end_with_dot
 
     TYPE_LABELS = {
       'A - Address record' => 'a',
@@ -52,11 +52,11 @@ module DnsService
       }.delete_if { |_k, v| v.blank? }
     end
 
-    def is_cname
-      if type == 'cname'
+    def end_with_dot
+      if type == 'cname' or type == 'mx'
         records.each do |value|
           unless /\A.+\.\z/.match?(value)
-            errors.add('records', 'The Canonical Name should end with a dot.')
+            errors.add('records', "#{CONTENT_LABELS[type.to_sym][:label]} should end with a dot.")
           end
         end
       end

--- a/plugins/dns_service/app/models/dns_service/recordset.rb
+++ b/plugins/dns_service/app/models/dns_service/recordset.rb
@@ -52,10 +52,17 @@ module DnsService
       }.delete_if { |_k, v| v.blank? }
     end
 
+    # cname: foo.bla.sap.
+    # mx:    10 smtpdem02.bla.sap.
+    # ptr:   1.0.0.10.in-addr.arpa.
+    # srv:   _service._proto.name. TTL class SRV priority weight port target.
     def end_with_dot
-      if type == 'cname' or type == 'mx'
+      if type == 'cname' or
+         type == 'mx' or
+         type == 'ptr' or
+         type == 'srv'
         records.each do |value|
-          unless /\A.+\.\z/.match?(value)
+          unless value.end_with?('.')
             errors.add('records', "#{CONTENT_LABELS[type.to_sym][:label]} should end with a dot.")
           end
         end


### PR DESCRIPTION
when creating DNS mx records sets for proper syntax.

WRONG! Elektra accepts these as valid:

`10 smtpdem02.mail.net, 10 smtpdem01.mail.net.`

but it should be:
`10 smtpdem02.mail.net., 10 smtpdem01.mail.net.`