### PR TITLE
new wizard step: Initialize Project Resources

### DIFF
--- a/plugins/identity/app/controllers/identity/projects_controller.rb
+++ b/plugins/identity/app/controllers/identity/projects_controller.rb
@@ -157,7 +157,12 @@ module Identity
       # check the order in /elektra/plugins/identity/spec/controllers/projects_controller_spec.rb
       %w[resource_management masterdata_cockpit networking].each do |service_name|
 
-        next unless services.available?(service_name.to_sym)
+        if service_name == 'resource_management'
+          next unless services.available?(:resources)
+        else
+          next unless services.available?(service_name.to_sym)
+        end
+
         # set instance variable service available to true
         instance_variable_set("@#{service_name}_service_available", true)
 
@@ -180,7 +185,7 @@ module Identity
     # RESOURCE MANAGEMENT
     def update_resource_management_wizard_status
 
-      if services.resource_management.has_project_quotas?(@scoped_domain_id, @scoped_project_id)
+      if services.resources.has_project_quotas?(@scoped_domain_id, @scoped_project_id)
         @project_profile.update_wizard_status('resource_management',ProjectProfile::STATUS_DONE)
       else
         @project_profile.update_wizard_status('resource_management', nil)

--- a/plugins/identity/app/controllers/identity/projects_controller.rb
+++ b/plugins/identity/app/controllers/identity/projects_controller.rb
@@ -136,7 +136,11 @@ module Identity
       # for all services that implements a wizard integration do
       # check the order in /elektra/plugins/identity/spec/controllers/projects_controller_spec.rb
       service_names = %w[masterdata_cockpit networking resource_management].keep_if do |name|
-        services.available?(name.to_sym)
+        if name == 'resource_management'
+          services.available?(:resources)
+        else
+          services.available?(name.to_sym)
+        end
       end
 
       # ProjectProfile /elektra/app/models

--- a/plugins/identity/app/controllers/identity/projects_controller.rb
+++ b/plugins/identity/app/controllers/identity/projects_controller.rb
@@ -183,34 +183,7 @@ module Identity
       if services.resource_management.has_project_quotas?(@scoped_domain_id, @scoped_project_id)
         @project_profile.update_wizard_status('resource_management',ProjectProfile::STATUS_DONE)
       else
-        # try to find a quota inquiry and get status of it
-        quota_inquiries = services.inquiry.get_inquiries({
-          kind: 'project_quota_package',
-          project_id: @scoped_project_id,
-          domain_id: @scoped_domain_id
-        })
-
-        quota_inquiries = quota_inquiries.select{|quota_inquiry| quota_inquiry.aasm_state!='closed'}
-
-        if quota_inquiries.length.positive?
-          approved_inquiries = quota_inquiries.select do |quota_inquiry|
-            quota_inquiry.aasm_state == 'approved'
-          end
-          status = approved_inquiries.length.positive? ? ProjectProfile::STATUS_DONE : ProjectProfile::STATUS_PENDING
-          inquiry = if approved_inquiries.length.positive?
-                      approved_inquiries.first
-                    else
-                      quota_inquiries.first
-                    end
-
-          @project_profile.update_wizard_status(
-            'resource_management',
-            status,
-            {inquiry_id: inquiry.id, aasm_state: inquiry.aasm_state, package: inquiry.payload["package"]}
-          )
-        else
-          @project_profile.update_wizard_status('resource_management', nil)
-        end
+        @project_profile.update_wizard_status('resource_management', nil)
       end
       @project_profile.wizard_finished?('resource_management')
     end

--- a/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
+++ b/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
@@ -55,7 +55,7 @@
 
   - if @project_profile.wizard_skipped?('resource_management')
     -# SKIPPED
-    = wizard_step({title: 'Request Resource Quotas',
+    = wizard_step({title: 'Resource Quotas',
       mandatory: true,
       status: 'skipped'}) do
       %p
@@ -63,24 +63,24 @@
         =link_to 'Resource Management',plugin('resource_management').resources_path()
   - elsif @project_profile.wizard_finished?('resource_management')
     -# DONE
-    = wizard_step({title: 'Request Resource Quotas',
+    = wizard_step({title: 'Resource Quotas',
       mandatory: true,
       status: 'done'}) do
       %p This project already has quota.
   - else
-    - action_button = { label: 'Request Quotas',
+    - action_button = { label: 'Initialize Quotas',
       url: can_setup_quota ? plugin('resources').init_project_path : nil,
       tooltip: can_setup_quota ? nil : "You don't have permissions to request quotas. Please check if you have one of the following roles: <b>#{required_roles}</b>"}
 
-    = wizard_step({title: 'Request Resource Quotas',
+    = wizard_step({title: 'Resource Quotas',
       mandatory: true,
       action_button: action_button,
       skip_button:( { label: 'Skip Step', url: plugin('resource_management').resources_skip_wizard_path(), data: {modal: true, wizard_action_button: true}} if can_setup_quota ),
       status: nil}) do
-      %p Here you can decide on the computing resources you want us to reserve for you. This is just an initial setting to get you started. If you realize at a later stage that you need more of something you can request more then.
+      %p Please select an initial allotment of compute, network and storage resources to get started with your project. If you realize at a later stage that you need more of something, you can request more then.
 
 - else
-  = wizard_step({title: 'Request Resource Quotas',
+  = wizard_step({title: 'Resource Quotas',
     mandatory: true,
     status: 'pending'}) do
     %p The Resource Management service is currently unavailable.

--- a/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
+++ b/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
@@ -48,9 +48,9 @@
 
 -# RESOURCE MANAGEMENT
 - if @resource_management_service_available
-  - can_setup_quota = current_user.is_allowed?("resource_management:project_resource_new_package_request")
+  - can_setup_quota = current_user.is_allowed?("resources:project:write_access")
   - quota_data = @project_profile.wizard_data('resource_management')
-  - required_roles = current_user.required_roles('resource_management:project_resource_new_package_request')
+  - required_roles = current_user.required_roles('resources:project:write_access')
   - required_roles = required_roles && required_roles.join(', ')
 
   - if @project_profile.wizard_skipped?('resource_management')
@@ -67,41 +67,17 @@
       mandatory: true,
       status: 'done'}) do
       %p This project already has quota.
-      - if quota_data and quota_data['aasm_state']=='approved'
-        %table.table.no-borders
-          %tbody
-            %tr
-              %th{width:"30%"} Package
-              %td= quota_data["package"]
   - else
-    -# IN PROCESS
-    - if quota_data
-      - if quota_data['aasm_state']=='open'
-        = wizard_step({title: 'Request Resource Quotas',
-          mandatory: true,
-          status: 'pending'}) do
-          %p
-            Your request is being checked. Please have some patience.
-            = link_to 'Show request', plugin('inquiry').inquiry_path(id: quota_data[:inquiry_id]), data: {modal: true}
+    - action_button = { label: 'Request Quotas',
+      url: can_setup_quota ? plugin('resources').init_project_path : nil,
+      tooltip: can_setup_quota ? nil : "You don't have permissions to request quotas. Please check if you have one of the following roles: <b>#{required_roles}</b>"}
 
-      - elsif quota_data['aasm_state']=='rejected'
-        = wizard_step({title: 'Request Resource Quotas',
-          mandatory: true,
-          action_button: ({label: 'Edit Request', url: plugin('inquiry').edit_inquiry_path(id: quota_data[:inquiry_id], state: 'open')} if can_setup_quota),
-          status: 'pending'}) do
-          %p Your request has been rejected. Please check the reason and reopen the request.
-
-    - else
-      - action_button = { label: 'Request Quotas',
-        url: can_setup_quota ? plugin('resource_management').resources_new_package_request_path : nil,
-        tooltip: can_setup_quota ? nil : "You don't have permissions to request quotas. Please check if you have one of the following roles: <b>#{required_roles}</b>"}
-
-      = wizard_step({title: 'Request Resource Quotas',
-        mandatory: true,
-        action_button: action_button,
-        skip_button:( { label: 'Skip Step', url: plugin('resource_management').resources_skip_wizard_path(), data: {modal: true, wizard_action_button: true}} if can_setup_quota ),
-        status: nil}) do
-        %p Here you can decide on the computing resources you want us to reserve for you. This is just an initial setting to get you started. If you realize at a later stage that you need more of something you can request more then.
+    = wizard_step({title: 'Request Resource Quotas',
+      mandatory: true,
+      action_button: action_button,
+      skip_button:( { label: 'Skip Step', url: plugin('resource_management').resources_skip_wizard_path(), data: {modal: true, wizard_action_button: true}} if can_setup_quota ),
+      status: nil}) do
+      %p Here you can decide on the computing resources you want us to reserve for you. This is just an initial setting to get you started. If you realize at a later stage that you need more of something you can request more then.
 
 - else
   = wizard_step({title: 'Request Resource Quotas',

--- a/plugins/identity/spec/controllers/projects_controller_spec.rb
+++ b/plugins/identity/spec/controllers/projects_controller_spec.rb
@@ -34,7 +34,7 @@ describe Identity::ProjectsController, type: :controller do
       allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
         .to receive(:available?).with(:networking).and_return(true)
       allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
-        .to receive(:available?).with(:resource_management).and_return(true)
+        .to receive(:available?).with(:resources).and_return(true)
     end
 
     context 'unfinshed wizard state' do
@@ -86,7 +86,7 @@ describe Identity::ProjectsController, type: :controller do
       allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
         .to receive(:available?).with(:networking).and_return(true)
       allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
-        .to receive(:available?).with(:resource_management).and_return(true)
+        .to receive(:available?).with(:resources).and_return(true)
     end
 
     it 'should set wizard_finished to true' do
@@ -125,7 +125,7 @@ describe Identity::ProjectsController, type: :controller do
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
           .to receive(:available?).with(:networking).and_return(true)
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
-          .to receive(:available?).with(:resource_management).and_return(true)
+          .to receive(:available?).with(:resources).and_return(true)
       end
 
       it 'should set resource_management_service_available to enabled' do
@@ -156,7 +156,7 @@ describe Identity::ProjectsController, type: :controller do
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
           .to receive(:available?).with(:networking).and_return(false)
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
-          .to receive(:available?).with(:resource_management).and_return(true)
+          .to receive(:available?).with(:resources).and_return(true)
       end
 
       it 'should set resource_management_service_available to enabled' do
@@ -187,7 +187,7 @@ describe Identity::ProjectsController, type: :controller do
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
           .to receive(:available?).with(:networking).and_return(false)
         allow_any_instance_of(::Core::ServiceLayer::ServicesManager)
-          .to receive(:available?).with(:resource_management).and_return(false)
+          .to receive(:available?).with(:resources).and_return(false)
       end
 
       it 'should no set resource_management_service_available' do

--- a/plugins/resource_management/app/services/service_layer/resource_management_service.rb
+++ b/plugins/resource_management/app/services/service_layer/resource_management_service.rb
@@ -91,21 +91,6 @@ module ServiceLayer
       end
     end
 
-    def has_project_quotas?(domain_id, project_id, project_domain_id = nil)
-      project = find_project(
-        domain_id || project_domain_id,
-        project_id,
-        service:  %w[compute network object-store],
-        resource: %w[instances ram cores networks capacity]
-      )
-      # return true if approved_quota of the resource networking:networks
-      # is greater than 0 OR
-      # return true if the sum of approved_quota of the resources
-      # compute:instances, compute:ram, compute:cores and
-      # object_storage:capacity is greater than 0
-      project.resources.any? { |r| r.quota.positive? }
-    end
-
     def list_projects(domain_id, query = {})
       # give the domain_id to enrich the Project object with domain_id
       elektron_limes.get("domains/#{domain_id}/projects", query).map_to(

--- a/plugins/resources/app/assets/stylesheets/resources/_application.scss
+++ b/plugins/resources/app/assets/stylesheets/resources/_application.scss
@@ -218,11 +218,6 @@ div.edit-quota-input {
       font-size: 18px;
       line-height: 18px;
       font-weight: bold;
-
-      i.fa {
-        /* different icons apparently have inconsistent widths */
-        width: 16px;
-      }
     }
 
     .muted-resources {

--- a/plugins/resources/app/assets/stylesheets/resources/_application.scss
+++ b/plugins/resources/app/assets/stylesheets/resources/_application.scss
@@ -170,6 +170,11 @@ div.edit-quota-input {
   margin-right: 2rem;
 }
 
+.alert + #package-selection {
+  /* compensate for the overly large margin-bottom of .alert */
+  margin-top: -10px;
+}
+
 #package-selection {
   display: flex;
 
@@ -191,6 +196,17 @@ div.edit-quota-input {
       border-color: #E2E8EA;
       border-top-color: #008FCC;
       background: #EEF7FB;
+    }
+
+    &.is-unavailable {
+      border-top-color: #CCC;
+      color: #888;
+      background: #FCFCFC;
+      cursor: not-allowed;
+
+      h3 {
+        color: #AAA;
+      }
     }
 
     &:not(:first-child) {

--- a/plugins/resources/app/assets/stylesheets/resources/_application.scss
+++ b/plugins/resources/app/assets/stylesheets/resources/_application.scss
@@ -169,3 +169,55 @@ div.edit-quota-input {
 .request-explanation {
   margin-right: 2rem;
 }
+
+#package-selection {
+  display: flex;
+  align-items: start;
+
+  .package {
+    flex: 1;
+    flex-basis: 0;
+    cursor: pointer;
+
+    /* look similar to .bs-callout.bs-callout-emphasize.bs-callout-info, but
+     * with different spacings and with the border at the top instead of at the
+     * left */
+    border: 1px solid #EEE;
+    border-top: 5px solid #00B3FF;
+    border-radius: 3px;
+    margin: 10px 0;
+    padding: 10px;
+
+    &.is-selected {
+      border-color: #E2E8EA;
+      border-top-color: #008FCC;
+      background: #EEF7FB;
+    }
+
+    &:not(:first-child) {
+      margin-left: 10px;
+    }
+
+    h3 {
+      margin: 0 0 14px 0;
+      font-size: 18px;
+      line-height: 18px;
+      font-weight: bold;
+
+      i.fa {
+        /* different icons apparently have inconsistent widths */
+        width: 16px;
+      }
+    }
+
+    .muted-resources {
+      font-size: 12px;
+
+      &::before {
+        display: block;
+        content: "Also includes:";
+        margin-top: 10px;
+      }
+    }
+  }
+}

--- a/plugins/resources/app/assets/stylesheets/resources/_application.scss
+++ b/plugins/resources/app/assets/stylesheets/resources/_application.scss
@@ -218,6 +218,13 @@ div.edit-quota-input {
       font-size: 18px;
       line-height: 18px;
       font-weight: bold;
+
+      /* the default width of .fa-fw is just slightly too large, and causes the
+       * heading "Object Storage" to break the line; so choose a narrower width
+       */
+      i.fa-fw {
+        width: 16px;
+      }
     }
 
     .muted-resources {

--- a/plugins/resources/app/assets/stylesheets/resources/_application.scss
+++ b/plugins/resources/app/assets/stylesheets/resources/_application.scss
@@ -172,7 +172,6 @@ div.edit-quota-input {
 
 #package-selection {
   display: flex;
-  align-items: start;
 
   .package {
     flex: 1;

--- a/plugins/resources/app/controllers/resources/application_controller.rb
+++ b/plugins/resources/app/controllers/resources/application_controller.rb
@@ -41,6 +41,19 @@ module Resources
       render action: 'show'
     end
 
+    def init_project
+      # This is the entrypoint for the "Initialize Project Resources" step in
+      # the project setup wizard. Note that it can only be used with
+      # `resources:project:edit` permissions.
+      @js_data[:project_id] = @scoped_project_id
+      @js_data[:domain_id]  = @scoped_domain_id
+      auth_params = { selected: @js_data }
+      enforce_permissions('::resources:project:edit', auth_params)
+      @js_data[:can_edit] = true
+
+      render action: 'init_project'
+    end
+
     def domain
       @scope = 'domain'
       @edit_role = 'resource_admin'

--- a/plugins/resources/app/javascript/app/components/applications/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/applications/init_project.jsx
@@ -1,0 +1,14 @@
+/* eslint no-console:0 */
+import Loader from '../../containers/loader';
+
+export default (props) => {
+  const { clusterId, domainId, projectId, flavorData } = props;
+  const scopeData = { clusterID: clusterId, domainID: domainId, projectID: projectId };
+  const rootProps = { flavorData, scopeData };
+
+  return <Loader scopeData={scopeData} isModal={true}>
+    <div className='modal-body'>
+      <p>Hello World</p>
+    </div>
+  </Loader>;
+};

--- a/plugins/resources/app/javascript/app/components/applications/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/applications/init_project.jsx
@@ -1,14 +1,13 @@
 /* eslint no-console:0 */
 import Loader from '../../containers/loader';
+import InitProjectModal from '../../containers/init_project';
 
 export default (props) => {
-  const { clusterId, domainId, projectId, flavorData } = props;
+  const { clusterId, domainId, projectId, docsUrl } = props;
   const scopeData = { clusterID: clusterId, domainID: domainId, projectID: projectId };
-  const rootProps = { flavorData, scopeData };
+  const rootProps = { scopeData, docsUrl };
 
   return <Loader scopeData={scopeData} isModal={true}>
-    <div className='modal-body'>
-      <p>Hello World</p>
-    </div>
+    <InitProjectModal {...rootProps} />
   </Loader>;
 };

--- a/plugins/resources/app/javascript/app/components/applications/main.jsx
+++ b/plugins/resources/app/javascript/app/components/applications/main.jsx
@@ -1,11 +1,11 @@
 /* eslint no-console:0 */
 import { HashRouter, Route, Redirect } from 'react-router-dom'
 
-import Loader from '../containers/loader';
-import Overview from '../containers/overview';
-import DetailsModal from '../containers/details/modal';
-import EditModal from '../containers/edit';
-import ProjectSettingsModal from '../containers/project/settings';
+import Loader from '../../containers/loader';
+import Overview from '../../containers/overview';
+import DetailsModal from '../../containers/details/modal';
+import EditModal from '../../containers/edit';
+import ProjectSettingsModal from '../../containers/project/settings';
 
 const routesForProjectLevel = (props) => {
   const { clusterId, domainId, projectId, flavorData, docsUrl, canEdit, isForeignScope } = props;

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -1,0 +1,138 @@
+import { WIZARD_RESOURCES } from '../constants';
+import { Unit } from '../unit';
+import { t, byUIString } from '../utils';
+
+export default class InitProjectModal extends React.Component {
+  //Computes the resource packages offered by this modal. Result looks like:
+  //
+  //    {
+  //      categoryName: {
+  //        resourceName: { "quota": 1, "quotaText": "1 GiB", "isHighlighted": true },
+  //        ...
+  //      },
+  //      ...
+  //    }
+  resourceValues() {
+    const { categories } = this.props;
+    if (!categories) {
+      //data from Limes is not yet loaded
+      return null;
+    }
+
+    const result = {};
+    for (const categoryName in WIZARD_RESOURCES) {
+      const categoryConf = WIZARD_RESOURCES[categoryName];
+      const category = categories[categoryName];
+      if (!category) {
+        continue;
+      }
+
+      //if WIZARD_RESOURCES does not state anything explicitly, highlight
+      //all the explicitly listed resources
+      const isHighlighted = categoryConf.highlight
+        ? name => categoryConf.highlight.indexOf(name) > -1
+        : name => categoryConf.resources[name] > 0;
+
+      const categoryResult = {};
+      for (const resource of category.resources) {
+        let quotaValue;
+        if (categoryConf.resources[resource.name]) {
+          //consider resources that are either explicitly listed in WIZARD_RESOURCES...
+          quotaValue = categoryConf.resources[resource.name];
+        } else if (resource.scales_with && categoryConf.resources[resource.scales_with.resource_name]) {
+          //...or which follow a resource that is
+          quotaValue = categoryConf.resources[resource.scales_with.resource_name]
+            * resource.scales_with.factor;
+        } else {
+          continue;
+        }
+
+        const unit = new Unit(resource.unit);
+        categoryResult[resource.name] = {
+          quota: quotaValue,
+          quotaText: unit.format(quotaValue),
+          isHighlighted: isHighlighted(resource.name),
+        };
+      }
+
+      result[categoryName] = categoryResult;
+    }
+    return result;
+  }
+
+  // close() {
+  //   Dashboard.hideModal();
+  //   document.location.reload();
+  // }
+
+  render() {
+    const { scopeData, docsUrl } = this.props;
+    const resourceValues = this.resourceValues();
+    if (!resourceValues) {
+      //data from Limes is not yet loaded
+      return null;
+    }
+    console.log(resourceValues);
+
+    return (
+      //NOTE: class='resources' is needed for CSS rules from plugins/resources/ to apply
+      <React.Fragment>
+        <div className='modal-body resources'>
+          <p>
+            Please select an initial allotment of resources for your project. Note that:
+          </p>
+          <ul>
+            <li>Quota assignments for some resources incur costs according to our
+              {" "}
+              <a href={`${docsUrl}docs/start/pricing.html`}>price list</a>.</li>
+            <li>You can always change your quotas later on. Large quota requests may be
+              {" "}
+              <a href={`${docsUrl}docs/quota/#auto-approval`}>subject to approval</a>.</li>
+          </ul>
+          <table className='table initial-packages'>
+            <thead><tr>
+              { Object.keys(resourceValues).map(categoryName => (
+                <th key={categoryName}>{t(categoryName)}</th>
+              ))}
+            </tr></thead>
+            <tbody>
+              <tr>
+                { Object.keys(resourceValues).map(categoryName => (
+                  <td key={categoryName}>{this.renderResourceList(resourceValues[categoryName], true)}</td>
+                ))}
+              </tr>
+              <tr className='text-muted'>
+                { Object.keys(resourceValues).map(categoryName => (
+                  <td key={categoryName}>{this.renderResourceList(resourceValues[categoryName], false)}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div className='buttons modal-footer'>
+          <div className='btn btn-primary'>Submit</div>
+          <div className='btn btn-default' onClick={() => Dashboard.hideModal()}>Cancel</div>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  renderResourceList(resources, isHighlighted) {
+    const rows = [];
+    const resourceNames = Object.keys(resources).sort(byUIString);
+
+    for (let resourceName of resourceNames) {
+      const resource = resources[resourceName];
+      if (resource.isHighlighted != isHighlighted) {
+        continue;
+      }
+
+      const typeText = resource.quotaText == '1'
+        ? t(resourceName + '_single')
+        : t(resourceName);
+      rows.push(<div key={resourceName}>{resource.quotaText} {typeText}</div>);
+    }
+
+    return rows;
+  }
+}

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -286,8 +286,8 @@ export default class InitProjectModal extends React.Component {
     if (isAvailable) {
       return box;
     } else {
-      const tooltip = <Tooltip>This package is not available right now, most likely because of missing domain quota. If you cannot proceed without it, please get in touch with your domain resource admin.</Tooltip>;
-      return <OverlayTrigger overlay={tooltip} placement='top'>{box}</OverlayTrigger>;
+      const tooltip = <Tooltip id={`package-unavailable-${categoryName}`}>This package is not available right now, most likely because of missing domain quota. If you cannot proceed without it, please get in touch with your domain resource admin.</Tooltip>;
+      return <OverlayTrigger overlay={tooltip} placement='top' key={categoryName}>{box}</OverlayTrigger>;
     }
   }
 }

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -289,7 +289,7 @@ export default class InitProjectModal extends React.Component {
     const box = (
       <div className={classes} key={categoryName} onClick={(e) => { e.preventDefault(); this.toggleCategory(categoryName); return false; }}>
         <h3>
-          <i className={isSelected ? 'fa fa-check-square' : 'fa fa-square-o'} />
+          <i className={isSelected ? 'fa fa-fw fa-check-square' : 'fa fa-fw fa-square-o'} />
           {' ' + t(categoryName)}
         </h3>
         <div className='highlighted-resources'>{highlightedResources}</div>

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -1,6 +1,6 @@
 import { WIZARD_RESOURCES } from '../constants';
 import { Unit } from '../unit';
-import { t, byUIString } from '../utils';
+import { t, byUIString, byNameIn } from '../utils';
 
 export default class InitProjectModal extends React.Component {
   constructor(props) {
@@ -89,6 +89,26 @@ export default class InitProjectModal extends React.Component {
       return null;
     }
 
+    //sorting predicate for categories: sort by area, then like on the main view
+    const infoForCategory = {};
+    for (const area of Object.keys(this.props.overview.areas)) {
+      const serviceTypes = this.props.overview.areas[area];
+      for (const serviceType of serviceTypes) {
+        for (const categoryName of this.props.overview.categories[serviceType]) {
+          infoForCategory[categoryName] = { serviceType, area };
+        }
+      }
+    }
+    const byAreaThenByName = (categoryNameA, categoryNameB) => {
+      const infoA = infoForCategory[categoryNameA];
+      const infoB = infoForCategory[categoryNameB];
+      if (infoA.area != infoB.area)
+        return byUIString(infoA.area, infoB.area);
+      if (infoA.serviceType != infoB.serviceType)
+        return byUIString(infoA.serviceType, infoB.serviceType);
+      return byNameIn(infoA.serviceType)(categoryNameA, categoryNameB);
+    };
+
     return (
       //NOTE: class='resources' is needed for CSS rules from plugins/resources/ to apply
       <React.Fragment>
@@ -105,7 +125,7 @@ export default class InitProjectModal extends React.Component {
               <a href={`${docsUrl}docs/quota/#auto-approval`}>subject to approval</a>.</li>
           </ul>
           <div id='package-selection'>
-            { Object.keys(resourceValues).sort(byUIString).map(categoryName => this.renderPackage(categoryName, resourceValues[categoryName])) }
+            { Object.keys(resourceValues).sort(byAreaThenByName).map(categoryName => this.renderPackage(categoryName, resourceValues[categoryName])) }
           </div>
         </div>
         <div className='buttons modal-footer'>
@@ -138,7 +158,7 @@ export default class InitProjectModal extends React.Component {
     return (
       <div className={isSelected ? 'package is-selected' : 'package'} key={categoryName} onClick={(e) => { e.preventDefault(); this.toggleCategory(categoryName); return false; }}>
         <h3>
-          <i class={isSelected ? 'fa fa-check-square' : 'fa fa-square-o'} />
+          <i className={isSelected ? 'fa fa-check-square' : 'fa fa-square-o'} />
           {' ' + t(categoryName)}
         </h3>
         <div className='highlighted-resources'>{highlightedResources}</div>

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -3,7 +3,7 @@ import { FormErrors } from 'lib/elektra-form/components/form_errors';
 
 import { WIZARD_RESOURCES } from '../constants';
 import { Unit } from '../unit';
-import { t, byUIString, byNameIn } from '../utils';
+import { t, byUIString, byNameIn, buttonCaption } from '../utils';
 
 export default class InitProjectModal extends React.Component {
   state = {
@@ -167,6 +167,19 @@ export default class InitProjectModal extends React.Component {
     this.setState({ ...this.state, isSelected });
   }
 
+  submit() {
+    if (this.state.isSubmitting) {
+      return;
+    }
+    this.setState({ ...this.state, isSubmitting: true });
+
+    const requestBody = this.makeRequestBody(this.props, this.state.isSelected);
+    this.props.setQuota(this.props.scopeData, requestBody)
+      .then(() => Dashboard.hideModal())
+      .catch(response => this.handleAPIErrors(response.errors));
+    console.log();
+  }
+
   // close() {
   //   Dashboard.hideModal();
   //   document.location.reload();
@@ -181,7 +194,6 @@ export default class InitProjectModal extends React.Component {
     });
   };
 
-
   render() {
     const { scopeData, docsUrl } = this.props;
     const resourceValues = this.resourceValues();
@@ -189,7 +201,9 @@ export default class InitProjectModal extends React.Component {
       //data from Limes is not yet loaded
       return null;
     }
-    if (this.state.isChecking) { 
+
+    const { isChecking, isSubmitting } = this.state;
+    if (isChecking) {
       //availability checks are not yet done
       return <div className='modal-body'>
         <p><span className='spinner'/> Checking package availability...</p>
@@ -225,7 +239,7 @@ export default class InitProjectModal extends React.Component {
             Please select an initial allotment of resources for your project. Note that:
           </p>
           <ul>
-            <li>Quota assignments for some resources incur costs according to our
+            <li>Quota assignments incur costs according to our
               {" "}
               <a href={`${docsUrl}docs/start/pricing.html`}>price list</a>.</li>
             <li>You can always change your quotas later on. Large quota requests may be
@@ -237,7 +251,7 @@ export default class InitProjectModal extends React.Component {
           </div>
         </div>
         <div className='buttons modal-footer'>
-          <div className='btn btn-primary'>Submit</div>
+          <div className='btn btn-primary' onClick={() => this.submit()} disabled={isSubmitting}>{buttonCaption('Submit', isSubmitting)}</div>
           <div className='btn btn-default' onClick={() => Dashboard.hideModal()}>Cancel</div>
         </div>
       </React.Fragment>

--- a/plugins/resources/app/javascript/app/components/init_project.jsx
+++ b/plugins/resources/app/javascript/app/components/init_project.jsx
@@ -1,3 +1,4 @@
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FormErrors } from 'lib/elektra-form/components/form_errors';
 
 import { WIZARD_RESOURCES } from '../constants';
@@ -215,15 +216,6 @@ export default class InitProjectModal extends React.Component {
       return byNameIn(infoA.serviceType)(categoryNameA, categoryNameB);
     };
 
-    const unavailablePackages = [];
-    if (this.state.isAvailable) {
-      for (const categoryName in this.state.isAvailable) {
-        if (!this.state.isAvailable[categoryName]) {
-          unavailablePackages.push(t(categoryName));
-        }
-      }
-    }
-
     return (
       //NOTE: class='resources' is needed for CSS rules from plugins/resources/ to apply
       <React.Fragment>
@@ -240,9 +232,6 @@ export default class InitProjectModal extends React.Component {
               {" "}
               <a href={`${docsUrl}docs/quota/#auto-approval`}>subject to approval</a>.</li>
           </ul>
-          {unavailablePackages.length > 0 && (
-            <p className='alert alert-warning'>Some packages ({unavailablePackages.sort().join(', ')}) are not available right now, most likely because of missing domain quota. If you cannot proceed without these packages, please get in touch with your domain resource admin.</p>
-          )}
           <div id='package-selection'>
             { Object.keys(resourceValues).sort(byAreaThenByName).map(categoryName => this.renderPackage(categoryName, resourceValues[categoryName])) }
           </div>
@@ -283,8 +272,8 @@ export default class InitProjectModal extends React.Component {
       classes += ' is-unavailable';
     }
 
-    return (
-      <div className={classes} title={isAvailable ? '' : 'Not available at this time'} key={categoryName} onClick={(e) => { e.preventDefault(); this.toggleCategory(categoryName); return false; }}>
+    const box = (
+      <div className={classes} key={categoryName} onClick={(e) => { e.preventDefault(); this.toggleCategory(categoryName); return false; }}>
         <h3>
           <i className={isSelected ? 'fa fa-check-square' : 'fa fa-square-o'} />
           {' ' + t(categoryName)}
@@ -293,5 +282,12 @@ export default class InitProjectModal extends React.Component {
         {mutedResources.length > 0 && <div className='muted-resources'>{mutedResources}</div>}
       </div>
     );
+
+    if (isAvailable) {
+      return box;
+    } else {
+      const tooltip = <Tooltip>This package is not available right now, most likely because of missing domain quota. If you cannot proceed without it, please get in touch with your domain resource admin.</Tooltip>;
+      return <OverlayTrigger overlay={tooltip} placement='top'>{box}</OverlayTrigger>;
+    }
   }
 }

--- a/plugins/resources/app/javascript/app/components/loader.jsx
+++ b/plugins/resources/app/javascript/app/components/loader.jsx
@@ -24,10 +24,12 @@ export default class Loader extends React.Component {
         isReloading={this.props.isFetching} />;
     }
     const scope = new Scope(this.props.scopeData);
-    if (this.props.isFetching) {
-      return <p><span className='spinner'/> Loading data for {scope.level()}...</p>;
-    }
-    return <p className='text-danger'>Failed to load data for {scope.level()}</p>;
+    const msg = this.props.isFetching
+      ? <p><span className='spinner'/> Loading data for {scope.level()}...</p>
+      : <p className='text-danger'>Failed to load data for {scope.level()}</p>;
+    return this.props.isModal
+      ? <div className='modal-body'>{msg}</div>
+      : msg;
   }
 
 }

--- a/plugins/resources/app/javascript/app/components/overview.jsx
+++ b/plugins/resources/app/javascript/app/components/overview.jsx
@@ -2,7 +2,7 @@ import moment from 'moment';
 import { Link } from 'react-router-dom';
 
 import { Scope } from '../scope';
-import { byUIString, t } from '../utils';
+import { byUIString, byNameIn, t } from '../utils';
 import Category from '../containers/category';
 import ProjectSyncAction from '../components/project/sync_action';
 
@@ -55,13 +55,6 @@ export default class Overview extends React.Component {
     const maxScrapedStr = moment.unix(Math.max(...currMaxScrapedAt, ...currScrapedAt)).fromNow(true);
     const ageDisplay = minScrapedStr == maxScrapedStr ? minScrapedStr : `between ${minScrapedStr} and ${maxScrapedStr}`;
 
-    //sorting predicate for categories: sort by translated name, but categories
-    //named after their service come first
-    const byNameIn = serviceType => (a, b) => {
-      if (t(serviceType) == t(a)) { return -1; }
-      if (t(serviceType) == t(b)) { return +1; }
-      return byUIString(a, b);
-    };
 
     const syncActionProps = {
       scopeData: props.scopeData,

--- a/plugins/resources/app/javascript/app/constants.js
+++ b/plugins/resources/app/javascript/app/constants.js
@@ -80,9 +80,11 @@ export const STRINGS = {
 
 export const WIZARD_RESOURCES = {
     "compute": {
+        "preselect": true,
         "resources": { "instances": 5 },
     },
     "networking": {
+        "preselect": true,
         "highlight": [ "floating_ips", "networks" ],
         "resources": { "floating_ips": 2, "networks": 1, "ports": 100, "rbac_policies": 5, "security_groups": 20, "security_group_rules": 100 },
     },

--- a/plugins/resources/app/javascript/app/constants.js
+++ b/plugins/resources/app/javascript/app/constants.js
@@ -86,13 +86,16 @@ export const WIZARD_RESOURCES = {
     "networking": {
         "preselect": true,
         "highlight": [ "floating_ips", "networks" ],
-        "resources": { "floating_ips": 2, "networks": 1, "ports": 100, "rbac_policies": 5, "security_groups": 20, "security_group_rules": 100 },
+        "resources": { "floating_ips": 2, "networks": 1, "ports": 500, "rbac_policies": 5, "security_groups": 20, "security_group_rules": 100 },
     },
     "loadbalancing": {
         "resources": { "loadbalancers": 1 },
     },
+    "dns": {
+        "resources": { "recordsets": 100 },
+    },
     "object-store": {
-        "resources": { "capacity": 1 << 30 }, // 1 GiB
+        "resources": { "capacity": 100 * (1 << 30) }, // 100 GiB
     },
     "volumev2": {
         "resources": { "volumes": 2 },

--- a/plugins/resources/app/javascript/app/constants.js
+++ b/plugins/resources/app/javascript/app/constants.js
@@ -77,3 +77,22 @@ export const STRINGS = {
     "zones":                       "Zones",
     "zones_single":                "Zone",
 };
+
+export const WIZARD_RESOURCES = {
+    "compute": {
+        "resources": { "instances": 5 },
+    },
+    "networking": {
+        "show": [ "floating_ips", "networks" ],
+        "resources": { "floating_ips": 2, "networks": 1, "ports": 100, "rbac_policies": 5, "security_groups": 20, "security_group_rules": 100 },
+    },
+    "loadbalancing": {
+        "resources": { "loadbalancers": 1 },
+    },
+    "object-store": {
+        "resources": { "capacity": 1 << 30 }, // 1 GiB
+    },
+    "volumev2": {
+        "resources": { "volumes": 2 },
+    },
+};

--- a/plugins/resources/app/javascript/app/constants.js
+++ b/plugins/resources/app/javascript/app/constants.js
@@ -83,7 +83,7 @@ export const WIZARD_RESOURCES = {
         "resources": { "instances": 5 },
     },
     "networking": {
-        "show": [ "floating_ips", "networks" ],
+        "highlight": [ "floating_ips", "networks" ],
         "resources": { "floating_ips": 2, "networks": 1, "ports": 100, "rbac_policies": 5, "security_groups": 20, "security_group_rules": 100 },
     },
     "loadbalancing": {

--- a/plugins/resources/app/javascript/app/containers/init_project.js
+++ b/plugins/resources/app/javascript/app/containers/init_project.js
@@ -1,5 +1,5 @@
 import { connect } from  'react-redux';
-import { setQuota } from '../actions/limes';
+import { setQuota, simulateSetQuota } from '../actions/limes';
 import InitProjectModal from '../components/init_project';
 
 export default connect(
@@ -9,6 +9,7 @@ export default connect(
     categories: state.limes.categories,
   }),
   dispatch => ({
-    setQuota: (...args) => dispatch(setQuota(...args)),
+    setQuota:         (...args) => dispatch(setQuota(...args)),
+    simulateSetQuota: (...args) => dispatch(simulateSetQuota(...args)),
   }),
 )(InitProjectModal);

--- a/plugins/resources/app/javascript/app/containers/init_project.js
+++ b/plugins/resources/app/javascript/app/containers/init_project.js
@@ -1,0 +1,14 @@
+import { connect } from  'react-redux';
+import { setQuota } from '../actions/limes';
+import InitProjectModal from '../components/init_project';
+
+export default connect(
+  (state, props) => ({
+    metadata:   state.limes.metadata,
+    overview:   state.limes.overview,
+    categories: state.limes.categories,
+  }),
+  dispatch => ({
+    setQuota: (...args) => dispatch(setQuota(...args)),
+  }),
+)(InitProjectModal);

--- a/plugins/resources/app/javascript/app/init.js
+++ b/plugins/resources/app/javascript/app/init.js
@@ -1,6 +1,7 @@
 import { createWidget } from 'widget';
 import * as reducers from './reducers';
-import App from './components/application';
+import MainApp from './components/applications/main';
+import InitProjectApp from './components/applications/init_project';
 
 createWidget(__dirname).then((widget) => {
   const limesHeaders = { 'X-Auth-Token': widget.config.scriptParams.token }
@@ -15,6 +16,18 @@ createWidget(__dirname).then((widget) => {
   delete(widget.config.scriptParams.limesApi)
   delete(widget.config.scriptParams.token)
 
+  //the script parameter "app" decides which entrypoint we're going to use
+  let app = MainApp;
+  switch (widget.config.scriptParams.app) {
+    case "main":
+      app = MainApp;
+      break;
+    case "init_project":
+      app = InitProjectApp;
+      break;
+  }
+  delete(widget.config.scriptParams.app)
+
   //convert params from strings into the respective types
   widget.config.scriptParams.flavorData = JSON.parse(widget.config.scriptParams.flavorData)
   widget.config.scriptParams.canEdit = widget.config.scriptParams.canEdit == 'true';
@@ -22,5 +35,5 @@ createWidget(__dirname).then((widget) => {
 
   widget.setPolicy()
   widget.createStore(reducers)
-  widget.render(App)
+  widget.render(app)
 })

--- a/plugins/resources/app/javascript/app/scope.js
+++ b/plugins/resources/app/javascript/app/scope.js
@@ -10,10 +10,13 @@ import ProjectResource from './components/project/resource';
 //     /domainname/resources/domain/othercluster/otherdomain
 //     ^^^^^^^^^^^^^^^^^^^^^^
 //
-const urlBaseRx = new RegExp(".*?\/resources\/");
+//Instead of "resources", we can also match "identity", to support the
+//"Initialize Project Resources" modal that is triggered from the project
+//wizard.
+const urlBaseRx = new RegExp("(.*?)\/(?:resources|identity)\/");
 
 export const getBaseURL = () => {
-  return urlBaseRx.exec(window.location.pathname)[0];
+  return urlBaseRx.exec(window.location.pathname)[1] + '/resources/';
 };
 
 /*

--- a/plugins/resources/app/javascript/app/utils.js
+++ b/plugins/resources/app/javascript/app/utils.js
@@ -31,6 +31,14 @@ export const byLeaderAndName = (resA, resB) => {
   return (keyA < keyB) ? -1 : (keyA > keyB) ? 1 : 0;
 };
 
+//A sorting predicate for categories: Sort by translated name, but categories
+//named after their service come first.
+export const byNameIn = serviceType => (a, b) => {
+  if (t(serviceType) == t(a)) { return -1; }
+  if (t(serviceType) == t(b)) { return +1; }
+  return byUIString(a, b);
+};
+
 //Formats large integer numbers for display by adding digit group separators.
 export const formatLargeInteger = (value) => {
   //The SI/ISO 31-0 standard recommends to separate each block of three

--- a/plugins/resources/app/services/service_layer/resources_service.rb
+++ b/plugins/resources/app/services/service_layer/resources_service.rb
@@ -15,12 +15,25 @@ module ServiceLayer
 
     def get_domain(domain_id)
       resp = elektron_resources.get("domains/#{domain_id}")
-      return resp.body['domain'] || { services: [] }
+      return resp.body['domain'] || { 'services' => [] }
     end
 
     def get_project(domain_id, project_id)
       resp = elektron_resources.get("domains/#{domain_id}/projects/#{project_id}")
-      return resp.body['project'] || { services: [] }
+      return resp.body['project'] || { 'services' => [] }
+    end
+
+    def has_project_quotas?(domain_id, project_id)
+      # look for any non-zero quota in a resource other than
+      # "network/security_groups" or "network/security_group_rules" (those
+      # start out non-zero because of the default security group)
+      get_project(domain_id, project_id)['services'].any? do |srv|
+        srv['resources'].any? do |res|
+          has_quota = (res['quota'] || 0) > 0
+          is_relevant = !/^security_group/.match?(res['name'] || '')
+          has_quota && is_relevant
+        end
+      end
     end
 
   end

--- a/plugins/resources/app/views/resources/application/init_project.html.haml
+++ b/plugins/resources/app/views/resources/application/init_project.html.haml
@@ -1,0 +1,5 @@
+= content_for :title do
+  Initialize Project Resources
+
+- @js_data[:app] = 'init_project'
+= javascript_pack_tag "resources_app", data: @js_data

--- a/plugins/resources/app/views/resources/application/show.html.haml
+++ b/plugins/resources/app/views/resources/application/show.html.haml
@@ -27,4 +27,5 @@
       %code= @edit_role
       role.
 
+- @js_data[:app] = 'main'
 = javascript_pack_tag "resources_app", data: @js_data

--- a/plugins/resources/config/policy.json
+++ b/plugins/resources/config/policy.json
@@ -35,6 +35,7 @@
    */
 
    "resources:project:access": "(rule:limes_project_view_roles or role:resource_admin) and not project_id:nil",
+   "resources:project:write_access": "role:resource_admin and not project_id:nil",
    "resources:domain:access": "(role:resource_viewer or role:resource_admin) and not domain_id:nil",
    "resources:cluster:access": "role:cloud_resource_viewer or role:cloud_resource_admin"
 

--- a/plugins/resources/config/routes.rb
+++ b/plugins/resources/config/routes.rb
@@ -20,4 +20,6 @@ Resources::Engine.routes.draw do
   post '/request/project' => 'request#project'
   post '/request/domain'  => 'request#domain'
 
+  get '/project/init' => 'application#init_project', as: 'init_project'
+
 end


### PR DESCRIPTION
The new implementation only requests quotas within auto-approval limits, so no request workflow is needed.

![grafik](https://user-images.githubusercontent.com/24696/56132606-b4812980-5f8a-11e9-8fcd-e49330ae98d4.png)

The screenshot shows an example situation where the domain has run out of Block Storage quota, so the respective package cannot be selected by the user. (The tooltip is shown because I hovered over the Block Storage package while taking the screenshot.)