### PR TITLE
Fix public-image step on the pipeline

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,17 +73,17 @@ ADD . /home/app/webapp
 # precompile assets including webpacker packs
 # We use dummy master.key to workaround the fact that
 # assets:precompile needs them but we don't want the real master.key to be built
-# into the container. The RAILS_MASTER_KEY should be injected as env var when starting the
+# into the container. The MONSOON_RAILS_SECRET_TOKEN should be injected as env var when starting the
 # container.
 # https://github.com/rails/rails/issues/32947
-RUN MONSOON_RAILS_SECRET_TOKEN='monsoon_rails_build_secret_token' bin/rails assets:precompile && rm -rf tmp/cache/assets
+ENV MONSOON_RAILS_SECRET_TOKEN=dummy_monsoon_rails_build_secret_token_for_precompiling_change_it_in_production
+RUN bin/rails assets:precompile && rm -rf tmp/cache/assets
 
 ENTRYPOINT ["dumb-init", "-c", "--" ]
 CMD ["script/start.sh"]
 
 FROM elektra AS tests
 RUN apk add --no-cache postgresql bash
-RUN unset MONSOON_RAILS_SECRET_TOKEN
 ENV RAILS_ENV=test
 RUN LISTENTO=127.0.0.1 su postgres -c 'script/pg_tmp.sh -p 5432 -w 300 -d /tmp/pg start' \
       && rake db:create db:migrate \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -76,7 +76,7 @@ ADD . /home/app/webapp
 # into the container. The MONSOON_RAILS_SECRET_TOKEN should be injected as env var when starting the
 # container.
 # https://github.com/rails/rails/issues/32947
-ENV MONSOON_RAILS_SECRET_TOKEN=dummy_monsoon_rails_build_secret_token_for_precompiling_change_it_in_production
+ENV MONSOON_RAILS_SECRET_TOKEN=dummy_monsoon_rails_build_secret_token_for_assets_precompiling_change_it_in_production
 RUN bin/rails assets:precompile && rm -rf tmp/cache/assets
 
 ENTRYPOINT ["dumb-init", "-c", "--" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,12 @@ RUN if [ -z ${http_proxy} ]; then \
 ADD . /home/app/webapp
 
 # precompile assets including webpacker packs
-RUN bin/rails assets:precompile && rm -rf tmp/cache/assets
+# We use dummy master.key to workaround the fact that
+# assets:precompile needs them but we don't want the real master.key to be built
+# into the container. The RAILS_MASTER_KEY should be injected as env var when starting the
+# container.
+# https://github.com/rails/rails/issues/32947
+RUN MONSOON_RAILS_SECRET_TOKEN='monsoon_rails_build_secret_token' bin/rails assets:precompile && rm -rf tmp/cache/assets
 
 ENTRYPOINT ["dumb-init", "-c", "--" ]
 CMD ["script/start.sh"]


### PR DESCRIPTION
Precompile assets including webpacker packs 
We use dummy master.key to workaround the fact that assets:precompile needs them but we don't want the real master.key to be built into the container. The MONSOON_RAILS_SECRET_TOKEN should be injected as env var when starting the container.