### PR TITLE
Network wizard skip option

### DIFF
--- a/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
+++ b/plugins/identity/app/views/identity/projects/_wizard_steps.html.haml
@@ -92,6 +92,7 @@
   = wizard_step({title: 'Configure Your Network',
     mandatory: true,
     action_button: (action_button if can_setup_network),
+    skip_button:( { label: 'Skip Step', url: plugin('networking').skip_wizard_path(), data: {modal: true, wizard_action_button: true}} if can_setup_network ),
     status: @project_profile.wizard_status('networking')}) do
     - if @project_profile.wizard_finished?('networking')
       %p The network is set up.

--- a/plugins/networking/app/controllers/networking/network_wizard_controller.rb
+++ b/plugins/networking/app/controllers/networking/network_wizard_controller.rb
@@ -64,6 +64,19 @@ module Networking
       end
     end
 
+    def skip_wizard_confirm
+      @project = "project"
+    end
+
+    def skip_wizard
+      skip_wizard = params[:project][:skip_wizard] || false
+      project_profile = ProjectProfile.find_or_create_by_project_id(@scoped_project_id)
+      
+      if skip_wizard
+        project_profile.update_wizard_status('networking',ProjectProfile::STATUS_SKIPPED)
+      end
+    end
+
     protected
 
     def cloud_admin_networking
@@ -84,5 +97,6 @@ module Networking
         target_tenant: @scoped_project_id
       )
     end
+
   end
 end

--- a/plugins/networking/app/views/networking/network_wizard/skip_wizard.js.erb
+++ b/plugins/networking/app/views/networking/network_wizard/skip_wizard.js.erb
@@ -1,0 +1,2 @@
+//close the window
+Dashboard.hideModal();

--- a/plugins/networking/app/views/networking/network_wizard/skip_wizard_confirm.html.haml
+++ b/plugins/networking/app/views/networking/network_wizard/skip_wizard_confirm.html.haml
@@ -14,7 +14,7 @@
                 %strong skip the network setup step
                 ? 
             %p
-                This can make sense in certain advanced custom setups. If this is the case for your project, feel free to skip this step.
+                This can make sense in certain custom setups. If this is the case for your project, feel free to skip this step.
 
 
     .buttons{class: modal? ? 'modal-footer' : ''}

--- a/plugins/networking/app/views/networking/network_wizard/skip_wizard_confirm.html.haml
+++ b/plugins/networking/app/views/networking/network_wizard/skip_wizard_confirm.html.haml
@@ -1,0 +1,25 @@
+= content_for(:title, "Skip Network Setup for Project #{}")
+
+=simple_form_for @project, url: plugin('networking').skip_wizard_path(), method: :post, remote: request.xhr?, html: { data: { modal: true } } do |f|
+
+    %div{class: modal? ? 'modal-body' : ''}
+        = f.input :skip_wizard,
+            as: :hidden,
+            input_html: { value: true }
+
+
+        .bs-callout.bs-callout-primary
+            %p
+                Are you sure you want to
+                %strong skip the network setup step
+                ? 
+            %p
+                This can make sense in certain advanced custom setups. If this is the case for your project, feel free to skip this step.
+
+
+    .buttons{class: modal? ? 'modal-footer' : ''}
+        - if modal?
+            %button.btn.btn-default{type:"button", data: { dismiss:"modal" }, aria: { label: "Cancel" }} Cancel
+        - else
+            = link_to "Cancel", data: {dismiss:"modal"}, class: 'btn btn-default'
+        %button.btn.btn-primary{type: "submit", data: { disable_with: 'Please wait...'}} I have a custom setup, please skip

--- a/plugins/networking/config/routes.rb
+++ b/plugins/networking/config/routes.rb
@@ -28,6 +28,12 @@ Networking::Engine.routes.draw do
 
   resources :backup_networks, only: %i[index new create]
   resources :network_wizard, only: %i[new create]
+    
+  scope :network_wizard do
+    get  'skip_wizard' => 'network_wizard#skip_wizard_confirm'
+    post 'skip_wizard' => 'network_wizard#skip_wizard'
+  end
+
 
   resources :network_usage_stats, only: %i[index]
 


### PR DESCRIPTION
For non-standard custom network setups so that these projects can get rid of the project wizard.