### PR TITLE
move serial log to modal, fixes #480

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -62,14 +62,15 @@ module Compute
           tenant_id: @scoped_project_id, id: sg.id
         ).first
       end.values
-
-      @log = begin 
-               services.compute.console_log(params[:id])
-             rescue 
-               nil
-             end  
     end
 
+    def console_log
+      @log = begin 
+        services.compute.console_log(params[:id])
+      rescue
+        nil
+      end
+    end
 
     def new
       # get usage from db

--- a/plugins/compute/app/views/compute/instances/_item.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item.html.haml
@@ -67,6 +67,7 @@
         %ul.dropdown-menu.dropdown-menu-right{ role:"menu"}
           - if current_user.is_allowed?("compute:instance_get", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
             %li= link_to 'VNC Console', console_instance_path(id: instance.id), target: '_blank'#data: { modal: true, load_console: true}
+            %li= link_to 'Serial Log', console_log_instance_path(id: instance.id), data: {modal: true }
             %li.divider
 
           -# Add other actions only if instance is not in a transitioning state (creating, starting, ...)

--- a/plugins/compute/app/views/compute/instances/_item.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item.html.haml
@@ -67,7 +67,7 @@
         %ul.dropdown-menu.dropdown-menu-right{ role:"menu"}
           - if current_user.is_allowed?("compute:instance_get", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
             %li= link_to 'VNC Console', console_instance_path(id: instance.id), target: '_blank'#data: { modal: true, load_console: true}
-            %li= link_to 'Serial Log', console_log_instance_path(id: instance.id), data: {modal: true }
+            / / Disabled until Serial LOg from nova side again %li= link_to 'Serial Log', console_log_instance_path(id: instance.id), data: {modal: true }
             %li.divider
 
           -# Add other actions only if instance is not in a transitioning state (creating, starting, ...)

--- a/plugins/compute/app/views/compute/instances/console_log.html.haml
+++ b/plugins/compute/app/views/compute/instances/console_log.html.haml
@@ -1,0 +1,14 @@
+= content_for :title do
+  %i.fa.fa-terminal
+  Serial Log
+
+.pre-scrollable
+  %pre
+    %code= @log || "No Log available"
+
+- if modal?
+  .modal-footer
+    - if modal?
+      %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Close"}} Close
+    - else
+      = link_to "Close", plugin('compute').instances_url, class: 'btn btn-default'

--- a/plugins/compute/app/views/compute/instances/show.html.haml
+++ b/plugins/compute/app/views/compute/instances/show.html.haml
@@ -11,7 +11,6 @@
     %ul.nav.nav-tabs
       %li.active{role: "presentation"}= link_to 'Information', '#information', aria: {controls:"information"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Specs', '#specs', aria: {controls:"specs"}, role: "tab", data: {toggle:"tab"}
-      %li{role: "presentation"}= link_to 'Serial Console', '#serial', aria: {controls:"serial"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'IP Addresses', '#ip_addresses', aria: {controls:"ip_addresses"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Security Groups', '#sec_groups', aria: {controls:"security_groups"}, role: "tab", data: {toggle:"tab"}
       %li{role: "presentation"}= link_to 'Key Pairs', '#keypairs', aria: {controls:"keypairs"}, role: "tab", data: {toggle:"tab"}
@@ -54,11 +53,6 @@
                 - else
                   = project_name(@instance.tenant_id)
       
-      .tab-pane{role:"tabpanel", id:"serial"}
-        .pre-scrollable
-          %pre
-            %code= @log || ''
-
       .tab-pane{role:"tabpanel", id:"specs"}
         - if @instance.flavor
           %table.table.datatable

--- a/plugins/compute/config/routes.rb
+++ b/plugins/compute/config/routes.rb
@@ -2,6 +2,7 @@ Compute::Engine.routes.draw do
   resources :instances do
     member do
       get 'console'
+      get 'console_log'
       get 'update_item'
       get 'new_size'
       get 'new_snapshot'


### PR DESCRIPTION
this will remove the server info tab 'serial log' and instead puts an
option to the advanced task menu of a server. Also makes calls
to os-getConsoleOutput deliberatily and not just by opening
the server info modal.