### PR TITLE
redirect /:domain_id/:project_id -> /:domain_id/:project_id/home

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
     get '/:domain_id/:project_id/home' => 'projects#show', as: :project_home
   end
 
+  get '/:domain_id/:project_id', to: redirect('/%{domain_id}/%{project_id}/home') 
+
   # route for overwritten High Voltage Pages controller
   get '/pages/*id' => 'pages#show', as: :core_page, format: false
 


### PR DESCRIPTION
There were some concerns that adding this redirect would break other routes but in my local tests it works and I couldn't find any broken project plugin links.