### PR TITLE
fix formatting resources overview

### DIFF
--- a/plugins/resources/app/javascript/app/components/overview.jsx
+++ b/plugins/resources/app/javascript/app/components/overview.jsx
@@ -91,10 +91,12 @@ export default class Overview extends React.Component {
   renderAvailabilityZoneTab() {
     const { flavorData } = this.props;
     const { bigVmResources } = this.props;
-    return <div>
-      <AvailabilityZoneOverview flavorData={flavorData} />;
-      <AvailableBigVmResources bigVmResources={bigVmResources} />
-    </div>
+    return (
+      <div>
+        <AvailabilityZoneOverview flavorData={flavorData} />
+        <AvailableBigVmResources bigVmResources={bigVmResources} />
+      </div>
+    );
   }
 
   renderAutoscalingTab() {


### PR DESCRIPTION
Hi, I noticed an additional semicolon in the "Manage Project Resources" > "Availability Zones" page.

Hope this fixes it ;)

Cheers,
Maurice