### PR TITLE
fix loadbalancing display when using octavia proxy

### DIFF
--- a/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/listeners/l7policies_controller.rb
+++ b/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/listeners/l7policies_controller.rb
@@ -17,7 +17,7 @@ module Loadbalancing
 
           @l7policies = []
           @l7policies = paginatable(per_page: per_page) do |pagination_options|
-            services.loadbalancing.l7policies({loadbalancer_id: params[:loadbalancer_id], listener_id: params[:listener_id],
+            services.loadbalancing.l7policies({listener_id: params[:listener_id],
                                                sort_key: 'position', sort_dir: 'asc'}.merge(pagination_options))
           end
           @pre_polices = get_unused_predefined_policies
@@ -101,7 +101,7 @@ module Loadbalancing
 
         def get_unused_predefined_policies
           @policies = Loadbalancing::L7policy.predefined(@listener.protocol )
-          used = services.loadbalancing.l7policies({loadbalancer_id: @loadbalancer.id, listener_id: @listener.id})
+          used = services.loadbalancing.l7policies({listener_id: @listener.id})
           pre_polices = []
           @policies.each do |p|
             p[:ids].each do |id|

--- a/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/listeners_controller.rb
+++ b/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/listeners_controller.rb
@@ -19,7 +19,7 @@ module Loadbalancing
         loadbalancer_id = params[:loadbalancer_id]
 
         @listeners = paginatable(per_page: per_page) do |pagination_options|
-          services.loadbalancing.listeners({loadbalancer_id: loadbalancer_id, sort_key: 'id', fields: 'id'}.merge(pagination_options))
+          services.loadbalancing.listeners({loadbalancer_id: loadbalancer_id, sort_key: 'id'}.merge(pagination_options))
         end
 
         # this is relevant in case an ajax paginate call is made.

--- a/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/pools_controller.rb
+++ b/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers/pools_controller.rb
@@ -18,7 +18,7 @@ module Loadbalancing
         loadbalancer_id = params[:loadbalancer_id]
 
         @pools = paginatable(per_page: per_page) do |pagination_options|
-          services.loadbalancing.pools({loadbalancer_id: loadbalancer_id, sort_key: 'id', fields: 'id'}.merge(pagination_options))
+          services.loadbalancing.pools({loadbalancer_id: loadbalancer_id, sort_key: 'id'}.merge(pagination_options))
         end
 
         # this is relevant in case an ajax paginate call is made.

--- a/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers_controller.rb
+++ b/plugins/loadbalancing/app/controllers/loadbalancing/loadbalancers_controller.rb
@@ -12,7 +12,7 @@ module Loadbalancing
       @loadbalancers = []
 
       @loadbalancers = paginatable(per_page: per_page) do |pagination_options|
-        services.loadbalancing.loadbalancers({tenant_id: @scoped_project_id, sort_key: 'id', fields: 'id'}.merge(pagination_options))
+        services.loadbalancing.loadbalancers({tenant_id: @scoped_project_id, sort_key: 'id'}.merge(pagination_options))
       end
 
       @fips = services.networking.project_floating_ips(@scoped_project_id)


### PR DESCRIPTION
This fixes displaying loadbalancer information since neutron used to ignore the fields=
attribute as well as l7policy display since loadbalancer_id is not used.