### PR TITLE
[shared_filesystem] show cloud admin pools for all types

### DIFF
--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_service.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_service.rb
@@ -13,7 +13,7 @@ module ServiceLayer
     include SharedFilesystemStorageServices::Snapshot
     include SharedFilesystemStorageServices::ErrorMessage
 
-    MICROVERSION = 2.44
+    MICROVERSION = 2.46
 
     def available?(_action_name_sym = nil)
       elektron.service?('sharev2')

--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
@@ -38,6 +38,12 @@ module ServiceLayer
         end
       end
 
+      def all_share_types
+        elektron_shares.get('types', {is_public: 'all'}).map_to('body.share_types') do |params|
+          SharedFilesystemStorage::ShareType.new(self, params)
+        end
+      end
+
       def share_export_locations(share_id)
         elektron_shares.get("shares/#{share_id}/export_locations").map_to(
           'body.export_locations'

--- a/plugins/shared_filesystem_storage/app/views/shared_filesystem_storage/cloud_admin/pools/_item.html.haml
+++ b/plugins/shared_filesystem_storage/app/views/shared_filesystem_storage/cloud_admin/pools/_item.html.haml
@@ -1,5 +1,5 @@
 %tr{id: "pool_#{pool.pool}"}
-  %td
+  %td= pool.type
   %td
     - if current_user.is_allowed?("shared_filesystem_storage:pool_get")
       = link_to pool.aggregate, plugin('shared_filesystem_storage').cloud_admin_pool_path(id: pool.aggregate), data: {modal: true}

--- a/plugins/shared_filesystem_storage/app/views/shared_filesystem_storage/cloud_admin/pools/index.html.haml
+++ b/plugins/shared_filesystem_storage/app/views/shared_filesystem_storage/cloud_admin/pools/index.html.haml
@@ -4,7 +4,7 @@
 %table.table
   %thead
     %tr
-      %th Availability Zone
+      %th Availability Zone / Type
       %th Aggregate
       %th Host
       %th Total Capacity


### PR DESCRIPTION
we will get more than one type, also in production soon and want to have an overview which pool is related to what type