### PR TITLE
[lbaas2]: remove not editable attribute admin_state_up

### DIFF
--- a/plugins/lbaas2/app/models/lbaas2/healthmonitor.rb
+++ b/plugins/lbaas2/app/models/lbaas2/healthmonitor.rb
@@ -45,8 +45,7 @@ module Lbaas2
         'http_method' => read('http_method'),
         'expected_codes' => read('expected_codes'),
         'url_path' => read('url_path'),
-        'tags' => read('tags'),
-        'admin_state_up' => read('admin_state_up')
+        'tags' => read('tags')
       }.delete_if { |_k, v| v.nil? }
     end
 

--- a/plugins/lbaas2/app/models/lbaas2/l7policy.rb
+++ b/plugins/lbaas2/app/models/lbaas2/l7policy.rb
@@ -25,7 +25,6 @@ module Lbaas2
       {
         'name'                => read('name'),
         'description'         => read('description'),
-        'admin_state_up'      => read('admin_state_up'),
         'position'            => read('position'),
         'action'              => read('action'),
         'redirect_url'        => read('redirect_url'),        

--- a/plugins/lbaas2/app/models/lbaas2/l7rule.rb
+++ b/plugins/lbaas2/app/models/lbaas2/l7rule.rb
@@ -58,7 +58,6 @@ module Lbaas2
     def attributes_for_update
       {
         'type'                => read('type'),
-        'admin_state_up'      => read('admin_state_up'),
         'compare_type'        => read('compare_type'),
         'invert'              => read('invert'),
         'value'               => read('value'),

--- a/plugins/lbaas2/app/models/lbaas2/listener.rb
+++ b/plugins/lbaas2/app/models/lbaas2/listener.rb
@@ -35,7 +35,6 @@ module Lbaas2
       {
         'name' => read('name'),
         'description' => read('description'),
-        'admin_state_up' => read('admin_state_up'),
         'connection_limit' => read('connection_limit'),
         'default_pool_id' => read('default_pool_id'),
         'default_tls_container_ref' => read('default_tls_container_ref'),

--- a/plugins/lbaas2/app/models/lbaas2/loadbalancer.rb
+++ b/plugins/lbaas2/app/models/lbaas2/loadbalancer.rb
@@ -23,7 +23,6 @@ module Lbaas2
       {
         'name'            => read('name'),
         'description'     => read('description'),
-        'admin_state_up'  => read('admin_state_up'),
         'tags'            => read('tags')
       }
     end

--- a/plugins/lbaas2/app/models/lbaas2/member.rb
+++ b/plugins/lbaas2/app/models/lbaas2/member.rb
@@ -24,10 +24,10 @@ module Lbaas2
       }.delete_if { |_k, v| v.blank? }
     end
 
+    # admin_state_up has been removed to prevent to send a nil object in the backend since this attribute will not be returned from the form
     def attributes_for_update
       {
         'name'            => read('name'),
-        'admin_state_up' => read('admin_state_up'),
         'weight'         => read('weight'),
         'tags'          => read('tags'),
         'backup'          => read('backup')

--- a/plugins/lbaas2/app/models/lbaas2/pool.rb
+++ b/plugins/lbaas2/app/models/lbaas2/pool.rb
@@ -39,7 +39,6 @@ module Lbaas2
         'description'               => read('description'),
         'lb_algorithm'              => read('lb_algorithm'),
         'session_persistence'       => read('session_persistence'),        
-        'admin_state_up'            => read('admin_state_up'),
         'tls_enabled'               => read('tls_enabled'),
         'tls_container_ref'         => read('tls_container_ref'),
         'ca_tls_container_ref'      => read('ca_tls_container_ref'),


### PR DESCRIPTION
Remove not editable attribute admin_state_up to prevent to send nil attribute to the backend
Fixes #791