### PR TITLE
[Barbican][Policy] Add support for yaml format as json format support…

### DIFF
--- a/plugins/key_manager/config/policy.yaml
+++ b/plugins/key_manager/config/policy.yaml
@@ -1,0 +1,21 @@
+# WARNING: Below rules are either deprecated rules
+# or extra rules in policy file, it is strongly
+# recommended to switch to new rules.
+"context_is_cloud_keymanager_admin": "role:cloud_keymanager_admin"
+"member": "role:member or role:Member"
+"keymanager_viewer": "role:keymanager_viewer"
+"keymanager_admin": "role:keymanager_admin"
+"context_is_keymanager_admin": "rule:context_is_cloud_keymanager_admin or rule:keymanager_admin"
+"context_is_keymanager_editor": "(rule:context_is_keymanager_admin) and not project_id:nil"
+"context_is_keymanager_viewer": "(rule:context_is_keymanager_editor or rule:keymanager_viewer) and not project_id:nil"
+"key_manager:secret_list": "rule:context_is_keymanager_viewer or rule:member"
+"key_manager:secret_get": "rule:context_is_keymanager_viewer or rule:member"
+"key_manager:secret_payload": "rule:context_is_keymanager_viewer or rule:member"
+"key_manager:secret_create": "rule:context_is_keymanager_editor or rule:member"
+"key_manager:secret_delete": "rule:context_is_keymanager_editor or rule:member"
+"key_manager:secret_update": "rule:context_is_keymanager_editor or rule:member"
+"key_manager:container_list": "rule:context_is_keymanager_viewer or rule:member"
+"key_manager:container_get": "rule:context_is_keymanager_viewer or rule:member"
+"key_manager:container_create": "rule:context_is_keymanager_editor or rule:member"
+"key_manager:container_delete": "rule:context_is_keymanager_editor or rule:member"
+"key_manager:container_update": "rule:context_is_keymanager_editor or rule:member"


### PR DESCRIPTION
… is depcreated in Victoria release

Hi @edda,

Openstack Victoria release has deprecated policy.json support, hence we need to switch policy.yaml.

Reference : https://docs.openstack.org/releasenotes/oslo.policy/victoria.html

I have switched openstack barbican to support policy.yaml in qa-de-1, it works well with CLI but i get permission denied if interacted via GUI. Could you please enable this fix only in qa-de-1 to test before rolling it to production ? Could you suggest how do we coordinate the rollout, as i plan to upgrade barbican 4 regions per week starting next week.

Regards,
Rajiv