### PR TITLE
Rename VNC console to Web Console

### DIFF
--- a/plugins/compute/app/assets/stylesheets/compute/_application.scss
+++ b/plugins/compute/app/assets/stylesheets/compute/_application.scss
@@ -32,7 +32,7 @@
   margin-top: 20px;
 }
 
-.vnc-console {
+.web-console {
   padding: 0;
   margin: 0;
 

--- a/plugins/compute/app/views/compute/instances/_item_actions.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item_actions.html.haml
@@ -5,7 +5,7 @@
 
   %ul.dropdown-menu.dropdown-menu-right{ role:"menu"}
     - if current_user.is_allowed?("compute:instance_get", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
-      %li= link_to 'VNC Console', console_instance_path(id: instance.id), target: '_blank'#data: { modal: true, load_console: true}
+      %li= link_to 'Web Console', console_instance_path(id: instance.id), target: '_blank'#data: { modal: true, load_console: true}
       / / Disabled until Serial LOg from nova side again %li= link_to 'Serial Log', console_log_instance_path(id: instance.id), data: {modal: true }
       %li.divider
 

--- a/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
+++ b/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
@@ -3,21 +3,21 @@
 
 = simple_modal_form_for @form, submit_action: 'Hard Reset', url: plugin('compute').pre_hard_reset_instance_path(id: @instance.id), method: :post, cancel_url: plugin('compute').console_instance_path(id: @instance.id) do |f|
   .bs-callout.bs-callout-danger
-    If your operating system does not respond to a restart signal you might need to hard reset your machine. 
-    That means the instance will be hard shutoff and afterwards switch back on. 
+    If your operating system does not respond to a restart signal you might need to hard reset your machine.
+    That means the instance will be hard shutoff and afterwards switch back on.
     %strong
-      This may result in data loss! 
-    Please double check in the console below that the instance is not currently in the process of performing 
+      This may result in data loss!
+    Please double check in the console below that the instance is not currently in the process of performing
     a soft reset or otherwise occupied.
     %br
     %br
     Are you sure you want to hard reset the instance
     %strong
-      = @instance.name 
+      = @instance.name
     ?
     %br
     %br
-    Note: after the hardreset is triggered the vnc console will stop to work. It will reload automaticly after the countdown ends.
+    Note: after the hardreset is triggered the web console will stop to work. It will reload automaticly after the countdown ends.
   .row
     .col-md-6
       %fieldset

--- a/plugins/compute/app/views/compute/instances/console.html.haml
+++ b/plugins/compute/app/views/compute/instances/console.html.haml
@@ -1,6 +1,6 @@
 = content_for :title do
   %i.fa.fa-terminal
-  VNC Console
+  Web Console
 
 - if modal?
   .modal-body.console

--- a/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
+++ b/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
@@ -10,14 +10,14 @@ Dashboard.hideModal();Dashboard
 var cnt = 15;
 // show countdown for reload
 $('#console').html("<div class='countdown'/>");
-$('.countdown').html('Hard Reset in process<br>VNC Console will reload in '+cnt+'s');
+$('.countdown').html('Hard Reset in process<br>Web Console will reload in '+cnt+'s');
 var x = setInterval(function() {
   cnt--;
   if (cnt == 0) {
     clearInterval(x);
-    $('.countdown').html('reloading VNC Console');
+    $('.countdown').html('reloading Web Console');
     window.location.replace("<%=plugin('compute').console_instance_path(id: @instance.id)%>");
   } else {
-    $('.countdown').html('Hard Reset in process<br>VNC Console will reload in '+cnt+'s');
+    $('.countdown').html('Hard Reset in process<br>Web Console will reload in '+cnt+'s');
   }
 }, 1000);

--- a/plugins/compute/app/views/layouts/compute/console.html.haml
+++ b/plugins/compute/app/views/layouts/compute/console.html.haml
@@ -16,10 +16,10 @@
     #modal-holder
 
   - hypervisor = @instance.attributes['OS-EXT-SRV-ATTR:host'] || ''
-  %body.vnc-console
+  %body.web-console
     .toolbar.toolbar-with-h
       %h5
-        VNC Console
+        Web Console
         %small (Click the blue bar to focus the console for keyboard input)
       .main-buttons
         - unless hypervisor.to_s.include?('nova-compute-ironic')


### PR DESCRIPTION
Originally, we were using a VNC session, but that is switched to an
MKS one since some time now.
And for ironic, we do use some different service altogether.
So we better name everything technology agnostic in order to avoid
confusion