### PR TITLE
[resources] Autoscaling fix

### DIFF
--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
@@ -23,10 +23,6 @@ const AutoscalingConfigSubscopeItem = ({
   isSaving,
   editMode,
 }) => {
-  const [tempMinFree, setTempMinFree] = React.useState(
-    minFree ? unit.format(minFree) : minFree
-  );
-
   const updateValue = React.useCallback(
     (newValue) => {
       //input sanitizing: only allow positive integer values
@@ -39,27 +35,26 @@ const AutoscalingConfigSubscopeItem = ({
       update(newValue);
       if (isUnset(newValue) || newValue === "") {
         updateMinFree(null);
-        setTempMinFree(null);
       }
     },
-    [update, updateMinFree, setTempMinFree]
+    [update, updateMinFree]
   );
 
   React.useEffect(() => {
-    if (!tempMinFree) {
+    if (!minFree) {
       updateMinFree(null);
       return;
     }
 
     if (!unit.name) {
-      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "");
+      const newValue = minFree.toString().replace(/[^0-9]+/, "");
       updateMinFree(parseInt(newValue));
       return;
     }
 
-    const parsedValue = unit.parse(tempMinFree);
+    const parsedValue = unit.parse(minFree);
     if (parsedValue.error) {
-      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "");
+      const newValue = minFree.toString().replace(/[^0-9]+/, "");
       updateMinFree(parseInt(newValue));
       return;
     } else {
@@ -67,7 +62,7 @@ const AutoscalingConfigSubscopeItem = ({
     }
     //input sanitizing: only allow positive integer values
     //newValue = newValue.replace(/[^0-9]+/, "")
-  }, [unit, tempMinFree]);
+  }, [JSON.stringify(unit), minFree]);
 
   const hasChanged = React.useMemo(() => {
     if (
@@ -137,9 +132,9 @@ const AutoscalingConfigSubscopeItem = ({
                     type="text"
                     className="form-control"
                     style={{ width: 100, display: "inline" }}
-                    value={isUnset(tempMinFree) ? "" : tempMinFree}
+                    value={isUnset(minFree) ? "" : minFree}
                     onKeyPress={(e) => e.key === "Enter" && save()}
-                    onChange={(e) => setTempMinFree(e.target.value)}
+                    onChange={(e) => updateMinFree(e.target.value)}
                   />{" "}
                   <br />
                   <div className="pull-right">

--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
@@ -1,5 +1,5 @@
-import { Button } from "react-bootstrap";
-import { isUnset } from "../helper";
+import { Button } from "react-bootstrap"
+import { isUnset } from "../helper"
 
 /**
  * Resource scope entry
@@ -26,43 +26,43 @@ const AutoscalingConfigSubscopeItem = ({
   const updateValue = React.useCallback(
     (newValue) => {
       //input sanitizing: only allow positive integer values
-      newValue = newValue.replace(/[^0-9]+/, "");
+      newValue = newValue.replace(/[^0-9]+/, "")
       //input sanitizing: do not allow values above 90%
       if (parseInt(newValue) > 90) {
-        newValue = "90";
+        newValue = "90"
       }
 
-      update(newValue);
+      update(newValue)
       if (isUnset(newValue) || newValue === "") {
-        updateMinFree(null);
+        updateMinFree(null)
       }
     },
     [update, updateMinFree]
-  );
+  )
 
   React.useEffect(() => {
     if (!minFree) {
-      updateMinFree(null);
-      return;
+      updateMinFree(null)
+      return
     }
 
     if (!unit.name) {
-      const newValue = minFree.toString().replace(/[^0-9]+/, "");
-      updateMinFree(parseInt(newValue));
-      return;
+      const newValue = minFree.toString().replace(/[^0-9]+/, "")
+      updateMinFree(parseInt(newValue))
+      return
     }
 
-    const parsedValue = unit.parse(minFree);
+    const parsedValue = unit.parse(minFree)
     if (parsedValue.error) {
-      const newValue = minFree.toString().replace(/[^0-9]+/, "");
-      updateMinFree(parseInt(newValue));
-      return;
+      const newValue = minFree.toString().replace(/[^0-9]+/, "")
+      updateMinFree(parseInt(newValue))
+      return
     } else {
-      updateMinFree(parsedValue);
+      updateMinFree(parsedValue)
     }
     //input sanitizing: only allow positive integer values
     //newValue = newValue.replace(/[^0-9]+/, "")
-  }, [JSON.stringify(unit), minFree]);
+  }, [JSON.stringify(unit), minFree])
 
   const hasChanged = React.useMemo(() => {
     if (
@@ -73,9 +73,9 @@ const AutoscalingConfigSubscopeItem = ({
         (originMinFree === null && minFree === "") ||
         String(originMinFree) === String(minFree))
     )
-      return false;
-    return true;
-  }, [value, originValue, minFree, originMinFree]);
+      return false
+    return true
+  }, [value, originValue, minFree, originMinFree])
 
   return (
     <>
@@ -115,9 +115,9 @@ const AutoscalingConfigSubscopeItem = ({
                     <a
                       href="#"
                       onClick={(e) => {
-                        e.preventDefault();
-                        updateValue("");
-                        updateMinFreeValue("");
+                        e.preventDefault()
+                        updateValue("")
+                        updateMinFreeValue("")
                       }}
                     >
                       clear
@@ -193,7 +193,7 @@ const AutoscalingConfigSubscopeItem = ({
         </td>
       </tr>
     </>
-  );
-};
+  )
+}
 
-export default AutoscalingConfigSubscopeItem;
+export default AutoscalingConfigSubscopeItem

--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js
@@ -1,5 +1,5 @@
-import { Button } from "react-bootstrap"
-import { isUnset } from "../helper"
+import { Button } from "react-bootstrap";
+import { isUnset } from "../helper";
 
 /**
  * Resource scope entry
@@ -25,49 +25,49 @@ const AutoscalingConfigSubscopeItem = ({
 }) => {
   const [tempMinFree, setTempMinFree] = React.useState(
     minFree ? unit.format(minFree) : minFree
-  )
+  );
 
   const updateValue = React.useCallback(
     (newValue) => {
       //input sanitizing: only allow positive integer values
-      newValue = newValue.replace(/[^0-9]+/, "")
+      newValue = newValue.replace(/[^0-9]+/, "");
       //input sanitizing: do not allow values above 90%
       if (parseInt(newValue) > 90) {
-        newValue = "90"
+        newValue = "90";
       }
 
-      update(newValue)
+      update(newValue);
       if (isUnset(newValue) || newValue === "") {
-        updateMinFree(null)
-        setTempMinFree(null)
+        updateMinFree(null);
+        setTempMinFree(null);
       }
     },
     [update, updateMinFree, setTempMinFree]
-  )
+  );
 
   React.useEffect(() => {
     if (!tempMinFree) {
-      updateMinFree(null)
-      return
+      updateMinFree(null);
+      return;
     }
 
     if (!unit.name) {
-      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "")
-      updateMinFree(parseInt(newValue))
-      return
+      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "");
+      updateMinFree(parseInt(newValue));
+      return;
     }
 
-    const parsedValue = unit.parse(tempMinFree)
+    const parsedValue = unit.parse(tempMinFree);
     if (parsedValue.error) {
-      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "")
-      updateMinFree(parseInt(newValue))
-      return
+      const newValue = tempMinFree.toString().replace(/[^0-9]+/, "");
+      updateMinFree(parseInt(newValue));
+      return;
     } else {
-      updateMinFree(parsedValue)
+      updateMinFree(parsedValue);
     }
     //input sanitizing: only allow positive integer values
     //newValue = newValue.replace(/[^0-9]+/, "")
-  }, [unit, tempMinFree])
+  }, [unit, tempMinFree]);
 
   const hasChanged = React.useMemo(() => {
     if (
@@ -78,9 +78,9 @@ const AutoscalingConfigSubscopeItem = ({
         (originMinFree === null && minFree === "") ||
         String(originMinFree) === String(minFree))
     )
-      return false
-    return true
-  }, [value, originValue, minFree, originMinFree])
+      return false;
+    return true;
+  }, [value, originValue, minFree, originMinFree]);
 
   return (
     <>
@@ -120,9 +120,9 @@ const AutoscalingConfigSubscopeItem = ({
                     <a
                       href="#"
                       onClick={(e) => {
-                        e.preventDefault()
-                        updateValue("")
-                        updateMinFreeValue("")
+                        e.preventDefault();
+                        updateValue("");
+                        updateMinFreeValue("");
                       }}
                     >
                       clear
@@ -198,7 +198,7 @@ const AutoscalingConfigSubscopeItem = ({
         </td>
       </tr>
     </>
-  )
-}
+  );
+};
 
-export default AutoscalingConfigSubscopeItem
+export default AutoscalingConfigSubscopeItem;

--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
@@ -1,8 +1,8 @@
-import { Table, FormControl, Button, Row, Col } from "react-bootstrap"
-import SubscopeItem from "./subscope_item"
-import { t } from "../../../utils"
-import { parseConfig, generateConfig, isUnset } from "../helper"
-import { Unit } from "../../../unit"
+import { Table, FormControl, Button, Row, Col } from "react-bootstrap";
+import SubscopeItem from "./subscope_item";
+import { t } from "../../../utils";
+import { parseConfig, generateConfig, isUnset } from "../helper";
+import { Unit } from "../../../unit";
 
 const styles = {
   detailsWrapper: {
@@ -22,7 +22,7 @@ const styles = {
     display: "flex",
     justifyContent: "space-between",
   },
-}
+};
 
 /****************************************
  * Details View
@@ -31,23 +31,23 @@ const styles = {
 function subscopesReducer(state, action) {
   switch (action.type) {
     case "init":
-      return { ...state, items: action.items }
+      return { ...state, items: action.items };
     case "editAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, error: null, editMode: true })),
-      }
+      };
     case "updateAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, value: action.value })),
-      }
+      };
 
     case "saveAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, isSaving: true, error: null })),
-      }
+      };
 
     case "savedAll":
       return {
@@ -58,7 +58,7 @@ function subscopesReducer(state, action) {
           editMode: false,
           error: null,
         })),
-      }
+      };
 
     case "cancelAll":
       return {
@@ -70,38 +70,38 @@ function subscopesReducer(state, action) {
           isSaving: false,
           value: i.originValue,
         })),
-      }
+      };
   }
 
-  const index = state.items.findIndex((i) => i.assetType === action.assetType)
-  if (index < 0) return state
-  const items = state.items.slice()
-  const item = items[index]
+  const index = state.items.findIndex((i) => i.assetType === action.assetType);
+  if (index < 0) return state;
+  const items = state.items.slice();
+  const item = items[index];
 
   switch (action.type) {
     case "update":
-      items[index] = { ...item, value: action.value }
-      return { ...state, items }
+      items[index] = { ...item, value: action.value };
+      return { ...state, items };
 
     case "updateMinFree":
-      items[index] = { ...item, minFree: action.value }
-      return { ...state, items }
+      items[index] = { ...item, minFree: action.value };
+      return { ...state, items };
 
     case "save":
-      items[index] = { ...item, isSaving: true, error: null }
-      return { ...state, items }
+      items[index] = { ...item, isSaving: true, error: null };
+      return { ...state, items };
 
     case "saved":
-      items[index] = { ...item, isSaving: false, editMode: false, error: null }
-      return { ...state, items }
+      items[index] = { ...item, isSaving: false, editMode: false, error: null };
+      return { ...state, items };
 
     case "error":
-      items[index] = { ...item, isSaving: false, error }
-      return { ...state, items }
+      items[index] = { ...item, isSaving: false, error };
+      return { ...state, items };
 
     case "edit":
-      items[index] = { ...item, error: null, editMode: true }
-      return { ...state, items }
+      items[index] = { ...item, error: null, editMode: true };
+      return { ...state, items };
 
     case "cancel":
       items[index] = {
@@ -110,11 +110,11 @@ function subscopesReducer(state, action) {
         editMode: false,
         isSaving: false,
         value: item.originValue,
-      }
-      return { ...state, items }
+      };
+      return { ...state, items };
 
     default:
-      throw new Error()
+      throw new Error();
   }
 }
 
@@ -130,35 +130,35 @@ const AutoscalingConfigNgSubscopes = ({
   updateConfig,
   deleteConfig,
 }) => {
-  const [height, setHeight] = React.useState(0)
-  const [searchTerm, setSearchTerm] = React.useState("")
+  const [height, setHeight] = React.useState(0);
+  const [searchTerm, setSearchTerm] = React.useState("");
 
   React.useEffect(() => {
-    const updateHeight = () => setHeight(window.innerHeight)
-    const closeOnEscape = (e) => e.key === "Escape" && onClose()
-    window.addEventListener("keyup", closeOnEscape)
-    window.addEventListener("resize", updateHeight)
-    updateHeight()
+    const updateHeight = () => setHeight(window.innerHeight);
+    const closeOnEscape = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keyup", closeOnEscape);
+    window.addEventListener("resize", updateHeight);
+    updateHeight();
     return () => {
-      window.removeEventListener("resize", updateHeight)
-      window.removeEventListener("keyup", closeOnEscape)
-    }
-  }, [])
+      window.removeEventListener("resize", updateHeight);
+      window.removeEventListener("keyup", closeOnEscape);
+    };
+  }, []);
 
   const [subscopesState, dispatch] = React.useReducer(subscopesReducer, {
     items: [],
-  })
+  });
 
-  const applyToAllRef = React.useRef()
-  const initialized = React.useRef(false)
+  const applyToAllRef = React.useRef();
+  const initialized = React.useRef(false);
 
   React.useEffect(() => {
     if (project?.subscopes) {
       dispatch({
         type: "init",
         items: project.subscopes.map((s) => {
-          const assetType = `project-quota:${s.service}:${s.resource}`
-          const parsedData = parseConfig(s.data, assetType)
+          const assetType = `project-quota:${s.service}:${s.resource}`;
+          const parsedData = parseConfig(s.data, assetType);
 
           return {
             assetType,
@@ -173,95 +173,95 @@ const AutoscalingConfigNgSubscopes = ({
             custom: parsedData?.custom,
             unit: new Unit(s.unitName),
             editMode: initialized.current !== project.id && editMode,
-          }
+          };
         }),
-      })
-      initialized.current = project.id
+      });
+      initialized.current = project.id;
     }
-  }, [project?.subscopes])
+  }, [project?.subscopes]);
 
   const submit = React.useCallback(
     (assetType, newValue, minFree) => {
-      if (!project?.id) return Promise.reject()
+      if (!project?.id) return Promise.reject();
       if (isUnset(newValue)) {
-        return deleteConfig(project.id, assetType)
+        return deleteConfig(project.id, assetType);
       } else {
-        const newValueInt = parseInt(newValue)
-        minFree = minFree && parseInt(minFree)
-        const cfg = generateConfig(newValueInt, minFree, assetType)
-        return updateConfig(project.id, assetType, cfg)
+        const newValueInt = parseInt(newValue);
+        minFree = minFree && parseInt(minFree);
+        const cfg = generateConfig(newValueInt, minFree, assetType);
+        return updateConfig(project.id, assetType, cfg);
       }
     },
     [project?.id]
-  )
+  );
 
   const save = React.useCallback(
     (assetType) => {
       if (!subscopesState.items)
-        return Promise.reject(new Error("no items in subscope state!"))
+        return Promise.reject(new Error("no items in subscope state!"));
 
       const subscope = subscopesState.items.find(
         (s) => s.assetType === assetType
-      )
+      );
 
       if (!subscope)
-        return Promise.reject(new Error(`subscope ${assetType} not found!`))
+        return Promise.reject(new Error(`subscope ${assetType} not found!`));
 
-      const newValue = isUnset(subscope.value) ? "" : subscope.value
+      const newValue = isUnset(subscope.value) ? "" : subscope.value;
       const originValue = isUnset(subscope.originValue)
         ? ""
-        : subscope.originValue
-      const newMinFree = subscope.minFree
-      const originMinFree = subscope.originMinFree
+        : subscope.originValue;
+      const newMinFree = subscope.minFree;
+      const originMinFree = subscope.originMinFree;
 
-      if (newValue === originValue && newMinFree === originMinFree) return
+      if (newValue === originValue && newMinFree === originMinFree) return;
 
-      dispatch({ type: "save", assetType })
+      dispatch({ type: "save", assetType });
       submit(assetType, newValue, newMinFree)
         .then(() => dispatch({ type: "saved", assetType }))
         .catch((error) =>
           dispatch({ type: "error", assetType, error: error.message })
-        )
+        );
     },
     [subscopesState]
-  )
+  );
 
   const saveAll = React.useCallback(() => {
-    dispatch({ type: "saveAll" })
-    const promises = []
+    dispatch({ type: "saveAll" });
+    const promises = [];
     for (let subscope of subscopesState.items) {
-      const newValue = isUnset(subscope.value) ? "" : subscope.value
+      const newValue = isUnset(subscope.value) ? "" : subscope.value;
       const originValue = isUnset(subscope.originValue)
         ? ""
-        : subscope.originValue
-      const newMinFree = subscope.minFree
-      const originMinFree = subscope.originMinFree
+        : subscope.originValue;
+      const newMinFree = subscope.minFree;
+      const originMinFree = subscope.originMinFree;
 
-      if (newValue === originValue && newMinFree === originMinFree) return
+      if (newValue === originValue && newMinFree === originMinFree) return;
 
       promises.push(
         submit(subscope.assetType, newValue, newMinFree).catch((error) =>
           dispatch({ type: "error", assetType, error: error.message })
         )
-      )
+      );
     }
-    Promise.all(promises).then(() => dispatch({ type: "savedAll" }))
-  }, [subscopesState, dispatch])
+    Promise.all(promises).then(() => dispatch({ type: "savedAll" }));
+  }, [subscopesState, dispatch]);
 
   const editAll = React.useCallback(
     () => dispatch({ type: "editAll" }),
     [dispatch]
-  )
+  );
 
   const cancelAll = React.useCallback(
     () => dispatch({ type: "cancelAll" }),
     [dispatch]
-  )
+  );
 
-  const [top, maxHeight] = React.useMemo(() => [93, height - 93], [height])
+  const [top, maxHeight] = React.useMemo(() => [93, height - 93], [height]);
 
   const filteredSubscopes = React.useMemo(() => {
-    let items = subscopesState.items || []
+    let items = subscopesState.items || [];
     if (searchTerm && searchTerm !== "") {
       items = items.filter(
         (s) =>
@@ -271,16 +271,16 @@ const AutoscalingConfigNgSubscopes = ({
             0 ||
             s.resourceLabel.toLowerCase().indexOf(searchTerm.toLowerCase()) >=
               0)
-      )
+      );
     }
     return items.sort((a, b) =>
       a.service < b.service ? -1 : a.service > b.service ? 1 : 0
-    )
-  }, [subscopesState, searchTerm])
+    );
+  }, [subscopesState, searchTerm]);
 
   const editModeCount = React.useMemo(
     () => filteredSubscopes.filter((s) => s.editMode).length
-  )
+  );
 
   return (
     <div
@@ -463,7 +463,7 @@ const AutoscalingConfigNgSubscopes = ({
         </>
       )}
     </div>
-  )
-}
+  );
+};
 
-export default AutoscalingConfigNgSubscopes
+export default AutoscalingConfigNgSubscopes;

--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
@@ -1,8 +1,8 @@
-import { Table, FormControl, Button, Row, Col } from "react-bootstrap";
-import SubscopeItem from "./subscope_item";
-import { t } from "../../../utils";
-import { parseConfig, generateConfig, isUnset } from "../helper";
-import { Unit } from "../../../unit";
+import { Table, FormControl, Button, Row, Col } from "react-bootstrap"
+import SubscopeItem from "./subscope_item"
+import { t } from "../../../utils"
+import { parseConfig, generateConfig, isUnset } from "../helper"
+import { Unit } from "../../../unit"
 
 const styles = {
   detailsWrapper: {
@@ -22,7 +22,7 @@ const styles = {
     display: "flex",
     justifyContent: "space-between",
   },
-};
+}
 
 /****************************************
  * Details View
@@ -31,23 +31,23 @@ const styles = {
 function subscopesReducer(state, action) {
   switch (action.type) {
     case "init":
-      return { ...state, items: action.items };
+      return { ...state, items: action.items }
     case "editAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, error: null, editMode: true })),
-      };
+      }
     case "updateAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, value: action.value })),
-      };
+      }
 
     case "saveAll":
       return {
         ...state,
         items: state.items.map((i) => ({ ...i, isSaving: true, error: null })),
-      };
+      }
 
     case "savedAll":
       return {
@@ -58,7 +58,7 @@ function subscopesReducer(state, action) {
           editMode: false,
           error: null,
         })),
-      };
+      }
 
     case "cancelAll":
       return {
@@ -70,38 +70,38 @@ function subscopesReducer(state, action) {
           isSaving: false,
           value: i.originValue,
         })),
-      };
+      }
   }
 
-  const index = state.items.findIndex((i) => i.assetType === action.assetType);
-  if (index < 0) return state;
-  const items = state.items.slice();
-  const item = items[index];
+  const index = state.items.findIndex((i) => i.assetType === action.assetType)
+  if (index < 0) return state
+  const items = state.items.slice()
+  const item = items[index]
 
   switch (action.type) {
     case "update":
-      items[index] = { ...item, value: action.value };
-      return { ...state, items };
+      items[index] = { ...item, value: action.value }
+      return { ...state, items }
 
     case "updateMinFree":
-      items[index] = { ...item, minFree: action.value };
-      return { ...state, items };
+      items[index] = { ...item, minFree: action.value }
+      return { ...state, items }
 
     case "save":
-      items[index] = { ...item, isSaving: true, error: null };
-      return { ...state, items };
+      items[index] = { ...item, isSaving: true, error: null }
+      return { ...state, items }
 
     case "saved":
-      items[index] = { ...item, isSaving: false, editMode: false, error: null };
-      return { ...state, items };
+      items[index] = { ...item, isSaving: false, editMode: false, error: null }
+      return { ...state, items }
 
     case "error":
-      items[index] = { ...item, isSaving: false, error };
-      return { ...state, items };
+      items[index] = { ...item, isSaving: false, error }
+      return { ...state, items }
 
     case "edit":
-      items[index] = { ...item, error: null, editMode: true };
-      return { ...state, items };
+      items[index] = { ...item, error: null, editMode: true }
+      return { ...state, items }
 
     case "cancel":
       items[index] = {
@@ -110,11 +110,11 @@ function subscopesReducer(state, action) {
         editMode: false,
         isSaving: false,
         value: item.originValue,
-      };
-      return { ...state, items };
+      }
+      return { ...state, items }
 
     default:
-      throw new Error();
+      throw new Error()
   }
 }
 
@@ -130,35 +130,35 @@ const AutoscalingConfigNgSubscopes = ({
   updateConfig,
   deleteConfig,
 }) => {
-  const [height, setHeight] = React.useState(0);
-  const [searchTerm, setSearchTerm] = React.useState("");
+  const [height, setHeight] = React.useState(0)
+  const [searchTerm, setSearchTerm] = React.useState("")
 
   React.useEffect(() => {
-    const updateHeight = () => setHeight(window.innerHeight);
-    const closeOnEscape = (e) => e.key === "Escape" && onClose();
-    window.addEventListener("keyup", closeOnEscape);
-    window.addEventListener("resize", updateHeight);
-    updateHeight();
+    const updateHeight = () => setHeight(window.innerHeight)
+    const closeOnEscape = (e) => e.key === "Escape" && onClose()
+    window.addEventListener("keyup", closeOnEscape)
+    window.addEventListener("resize", updateHeight)
+    updateHeight()
     return () => {
-      window.removeEventListener("resize", updateHeight);
-      window.removeEventListener("keyup", closeOnEscape);
-    };
-  }, []);
+      window.removeEventListener("resize", updateHeight)
+      window.removeEventListener("keyup", closeOnEscape)
+    }
+  }, [])
 
   const [subscopesState, dispatch] = React.useReducer(subscopesReducer, {
     items: [],
-  });
+  })
 
-  const applyToAllRef = React.useRef();
-  const initialized = React.useRef(false);
+  const applyToAllRef = React.useRef()
+  const initialized = React.useRef(false)
 
   React.useEffect(() => {
     if (project?.subscopes) {
       dispatch({
         type: "init",
         items: project.subscopes.map((s) => {
-          const assetType = `project-quota:${s.service}:${s.resource}`;
-          const parsedData = parseConfig(s.data, assetType);
+          const assetType = `project-quota:${s.service}:${s.resource}`
+          const parsedData = parseConfig(s.data, assetType)
 
           return {
             assetType,
@@ -173,95 +173,95 @@ const AutoscalingConfigNgSubscopes = ({
             custom: parsedData?.custom,
             unit: new Unit(s.unitName),
             editMode: initialized.current !== project.id && editMode,
-          };
+          }
         }),
-      });
-      initialized.current = project.id;
+      })
+      initialized.current = project.id
     }
-  }, [project?.subscopes]);
+  }, [project?.subscopes])
 
   const submit = React.useCallback(
     (assetType, newValue, minFree) => {
-      if (!project?.id) return Promise.reject();
+      if (!project?.id) return Promise.reject()
       if (isUnset(newValue)) {
-        return deleteConfig(project.id, assetType);
+        return deleteConfig(project.id, assetType)
       } else {
-        const newValueInt = parseInt(newValue);
-        minFree = minFree && parseInt(minFree);
-        const cfg = generateConfig(newValueInt, minFree, assetType);
-        return updateConfig(project.id, assetType, cfg);
+        const newValueInt = parseInt(newValue)
+        minFree = minFree && parseInt(minFree)
+        const cfg = generateConfig(newValueInt, minFree, assetType)
+        return updateConfig(project.id, assetType, cfg)
       }
     },
     [project?.id]
-  );
+  )
 
   const save = React.useCallback(
     (assetType) => {
       if (!subscopesState.items)
-        return Promise.reject(new Error("no items in subscope state!"));
+        return Promise.reject(new Error("no items in subscope state!"))
 
       const subscope = subscopesState.items.find(
         (s) => s.assetType === assetType
-      );
+      )
 
       if (!subscope)
-        return Promise.reject(new Error(`subscope ${assetType} not found!`));
+        return Promise.reject(new Error(`subscope ${assetType} not found!`))
 
-      const newValue = isUnset(subscope.value) ? "" : subscope.value;
+      const newValue = isUnset(subscope.value) ? "" : subscope.value
       const originValue = isUnset(subscope.originValue)
         ? ""
-        : subscope.originValue;
-      const newMinFree = subscope.minFree;
-      const originMinFree = subscope.originMinFree;
+        : subscope.originValue
+      const newMinFree = subscope.minFree
+      const originMinFree = subscope.originMinFree
 
-      if (newValue === originValue && newMinFree === originMinFree) return;
+      if (newValue === originValue && newMinFree === originMinFree) return
 
-      dispatch({ type: "save", assetType });
+      dispatch({ type: "save", assetType })
       submit(assetType, newValue, newMinFree)
         .then(() => dispatch({ type: "saved", assetType }))
         .catch((error) =>
           dispatch({ type: "error", assetType, error: error.message })
-        );
+        )
     },
     [subscopesState]
-  );
+  )
 
   const saveAll = React.useCallback(() => {
-    dispatch({ type: "saveAll" });
-    const promises = [];
+    dispatch({ type: "saveAll" })
+    const promises = []
     for (let subscope of subscopesState.items) {
-      const newValue = isUnset(subscope.value) ? "" : subscope.value;
+      const newValue = isUnset(subscope.value) ? "" : subscope.value
       const originValue = isUnset(subscope.originValue)
         ? ""
-        : subscope.originValue;
-      const newMinFree = subscope.minFree;
-      const originMinFree = subscope.originMinFree;
+        : subscope.originValue
+      const newMinFree = subscope.minFree
+      const originMinFree = subscope.originMinFree
 
-      if (newValue === originValue && newMinFree === originMinFree) return;
+      if (newValue === originValue && newMinFree === originMinFree) return
 
       promises.push(
         submit(subscope.assetType, newValue, newMinFree).catch((error) =>
           dispatch({ type: "error", assetType, error: error.message })
         )
-      );
+      )
     }
-    Promise.all(promises).then(() => dispatch({ type: "savedAll" }));
-  }, [subscopesState, dispatch]);
+    Promise.all(promises).then(() => dispatch({ type: "savedAll" }))
+  }, [subscopesState, dispatch])
 
   const editAll = React.useCallback(
     () => dispatch({ type: "editAll" }),
     [dispatch]
-  );
+  )
 
   const cancelAll = React.useCallback(
     () => dispatch({ type: "cancelAll" }),
     [dispatch]
-  );
+  )
 
-  const [top, maxHeight] = React.useMemo(() => [93, height - 93], [height]);
+  const [top, maxHeight] = React.useMemo(() => [93, height - 93], [height])
 
   const filteredSubscopes = React.useMemo(() => {
-    let items = subscopesState.items || [];
+    let items = subscopesState.items || []
     if (searchTerm && searchTerm !== "") {
       items = items.filter(
         (s) =>
@@ -271,17 +271,17 @@ const AutoscalingConfigNgSubscopes = ({
             0 ||
             s.resourceLabel.toLowerCase().indexOf(searchTerm.toLowerCase()) >=
               0)
-      );
+      )
     }
     return items.sort((a, b) =>
       a.service < b.service ? -1 : a.service > b.service ? 1 : 0
-    );
-  }, [JSON.stringify(subscopesState), searchTerm]);
+    )
+  }, [JSON.stringify(subscopesState), searchTerm])
 
   const editModeCount = React.useMemo(
     () => filteredSubscopes.filter((s) => s.editMode).length,
     [JSON.stringify(filteredSubscopes)]
-  );
+  )
 
   return (
     <div
@@ -464,7 +464,7 @@ const AutoscalingConfigNgSubscopes = ({
         </>
       )}
     </div>
-  );
-};
+  )
+}
 
-export default AutoscalingConfigNgSubscopes;
+export default AutoscalingConfigNgSubscopes

--- a/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
+++ b/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscopes.js
@@ -276,10 +276,11 @@ const AutoscalingConfigNgSubscopes = ({
     return items.sort((a, b) =>
       a.service < b.service ? -1 : a.service > b.service ? 1 : 0
     );
-  }, [subscopesState, searchTerm]);
+  }, [JSON.stringify(subscopesState), searchTerm]);
 
   const editModeCount = React.useMemo(
-    () => filteredSubscopes.filter((s) => s.editMode).length
+    () => filteredSubscopes.filter((s) => s.editMode).length,
+    [JSON.stringify(filteredSubscopes)]
   );
 
   return (


### PR DESCRIPTION
Long story short...
tempMinfree was created once when the modal view was loaded. 
https://github.com/sapcc/elektra/blob/master/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js#L26

When switching the different autoscaling projects react.useffect was triggered updating the minFree in the State with the NOT updated tempMinFree set when the modal view was opened for first time. The trigger was not the tempMinFree itself but the unit.
https://github.com/sapcc/elektra/blob/master/plugins/resources/app/javascript/app/components/autoscaling/config_ng/subscope_item.js#L48

I didn't see any benefit of using this tempMinFree so I removed it and instead the state is being updated directly. @andypf can do a double check before merging.

cc @majewsky 
fixes #992 