### PR TITLE
Introduce new Objectstore Roles

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -51,5 +51,7 @@ BLACKLISTED_ROLES = %w[
   cloud_resource_admin
   cloud_resource_viewer
   resource_service
+  cloud_objectstore_admin
+  cloud_objectstore_viewer
   swiftreseller
 ].freeze

--- a/plugins/identity/config/locales/en.yml
+++ b/plugins/identity/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
     cloud_sharedfilesystem_admin: Manila Cloud Administrator
     cloud_sharedfilesystem_viewer: Manila Cloud Read-Only
     cloud_volume_admin: Cinder Cloud Administrator
+    cloud_objectstore_admin: Swift Cloud Administrator
+    cloud_objectstore_viewer: Swift Cloud Read-Only
     compute_admin: Nova Administrator
     compute_admin_wsg: Nova Administrator without Securitygroup Management
     compute_viewer: Nova Read-Only
@@ -39,6 +41,8 @@ en:
     sharedfilesystem_viewer: Manila Read-Only
     swiftoperator: Object Store Administrator
     swiftreseller: Object Store Cloud Administrator
+    objectstore_admin: Swift Administrator
+    objectstore_viewer: Swift Read-Only
     volume_admin: Cinder Administrator
     volume_viewer: Cinder Read-Only
     securitygroup_viewer: Security Group Read-Only

--- a/plugins/object_storage/config/policy.json
+++ b/plugins/object_storage/config/policy.json
@@ -1,10 +1,13 @@
 {
-  "object_storage_admin": "role:admin or role:swiftoperator",
+  "object_storage_admin": "role:admin or role:swiftoperator or role:objectstore_admin",
+  "object_storage_viewer": "role:objectstore_viewer or rule:object_storage_admin",
   "object_storage:entry_list": "not project_id:nil",
-  
-  "object_storage:container_get":                   "rule:object_storage_admin",
-  "object_storage:container_check_acls":            "rule:object_storage_admin",
-  "object_storage:container_list":                  "rule:object_storage_admin",
+
+  "object_storage:container_get":                   "rule:object_storage_viewer",
+  "object_storage:container_check_acls":            "rule:object_storage_viewer",
+  "object_storage:container_show_access_control":   "rule:object_storage_viewer",
+  "object_storage:container_list":                  "rule:object_storage_viewer",
+
   "object_storage:container_new":                   "rule:object_storage_admin",
   "object_storage:container_create":                "rule:object_storage_admin",
   "object_storage:container_update":                "rule:object_storage_admin",
@@ -13,14 +16,14 @@
   "object_storage:container_pre_empty":             "rule:object_storage_admin",
   "object_storage:container_confirm_deletion":      "rule:object_storage_admin",
   "object_storage:container_confirm_emptying":      "rule:object_storage_admin",
-  "object_storage:container_show_access_control":   "rule:object_storage_admin",
   "object_storage:container_update_access_control": "rule:object_storage_admin",
 
-  "object_storage:object_get":           "rule:object_storage_admin",
-  "object_storage:object_list":          "rule:object_storage_admin",
+  "object_storage:object_get":           "rule:object_storage_viewer",
+  "object_storage:object_list":          "rule:object_storage_viewer",
+  "object_storage:object_download":      "rule:object_storage_viewer",
+
   "object_storage:object_update":        "rule:object_storage_admin",
   "object_storage:object_delete":        "rule:object_storage_admin",
-  "object_storage:object_download":      "rule:object_storage_admin",
   "object_storage:object_new_copy":      "rule:object_storage_admin",
   "object_storage:object_create_copy":   "rule:object_storage_admin",
   "object_storage:object_move":          "rule:object_storage_admin",


### PR DESCRIPTION
* Introduce `object_storage_viewer` policy and allow read access
* blacklist `cloud_objectstore_*` roles
* locals for new roles

TODO: After rollout and migration remove references to `swiftoperator`