### PR TITLE
[shared_filesystem_storage] bump microversion to max in xena release

### DIFF
--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_service.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_service.rb
@@ -14,7 +14,7 @@ module ServiceLayer
     include SharedFilesystemStorageServices::Snapshot
     include SharedFilesystemStorageServices::ErrorMessage
 
-    MICROVERSION = 2.44
+    MICROVERSION = 2.65
 
     def available?(_action_name_sym = nil)
       elektron.service?('sharev2')

--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/replica.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/replica.rb
@@ -4,31 +4,23 @@ module ServiceLayer
   module SharedFilesystemStorageServices
     module Replica
 
-      # need to use api version 2.56 
-      def elektron_share_replicas
-        @elektron_share_replicas ||= elektron.service(
-          'sharev2',
-          headers: { 'X-OpenStack-Manila-API-Version' => "2.56" }
-        )
-      end
-
       def replica_map
         @replica_map ||= class_map_proc(SharedFilesystemStorage::Replica)
       end
 
       def replicas(filter = {})
-        elektron_share_replicas.get('share-replicas', filter)
-                       .map_to('body.share_replicas', &replica_map)           
+        elektron_shares.get('share-replicas', filter)
+                       .map_to('body.share_replicas', &replica_map)
       end
 
       def replicas_detail(filter = {})
-        elektron_share_replicas.get('share-replicas/detail', filter)
+        elektron_shares.get('share-replicas/detail', filter)
                        .map_to('body.share_replicas', &replica_map)
 
       end
 
       def find_replica!(id)
-        elektron_share_replicas.get("share-replicas/#{id}")
+        elektron_shares.get("share-replicas/#{id}")
                        .map_to('body.share_replica', &share_map)
       end
 
@@ -44,26 +36,26 @@ module ServiceLayer
 
       ################# INTERFACE METHODS ######################
       def create_replica(params)
-        elektron_share_replicas.post('share-replicas') do
+        elektron_shares.post('share-replicas') do
           { share_replica: params }
         end.body['share_replica']
       end
 
       def resync_replica(id)
-        elektron_share_replicas.post("share-replicas/#{id}/action") do
+        elektron_shares.post("share-replicas/#{id}/action") do
          { resync: true }
         end.body['share_replica']
       end
 
       def promote_replica(id)
         # byebug
-        elektron_share_replicas.post("share-replicas/#{id}/action") do
+        elektron_shares.post("share-replicas/#{id}/action") do
           { promote: true }
         end.body['share_replica']
       end
 
       def delete_replica(id)
-        elektron_share_replicas.delete("share-replicas/#{id}")
+        elektron_shares.delete("share-replicas/#{id}")
       end
     end
   end

--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share.rb
@@ -39,11 +39,9 @@ module ServiceLayer
       end
 
       def all_share_types
-        # to retrieve 'is_default' flag we need at least microversion 2.46
-        elektron.service(
-          'sharev2',
-          headers: { 'X-OpenStack-Manila-API-Version' => "2.46" }
-          ).get('types', {is_public: 'all'}).map_to('body.share_types') do |params|
+        elektron_shares.get('types', {is_public: 'all'}).map_to(
+          'body.share_types'
+        ) do |params|
             SharedFilesystemStorage::ShareType.new(self, params)
         end
       end

--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share_rule.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/share_rule.rb
@@ -4,12 +4,23 @@ module ServiceLayer
   module SharedFilesystemStorageServices
     # This module implements Openstack Designate Pool API
     module ShareRule
+
+      # need to use api version 2.44
+      # 2.45 removes this access api via POST /action
+      # and introduces GET /share-access-rules
+      def elektron_share_access
+        @elektron_share_access ||= elektron.service(
+          'sharev2',
+          headers: { 'X-OpenStack-Manila-API-Version' => "2.44" }
+        )
+      end
+
       def share_rule_map
         @share_rule_map ||= class_map_proc(SharedFilesystemStorage::ShareRule)
       end
 
       def share_rules(share_id)
-        elektron_shares.post("shares/#{share_id}/action") do
+        elektron_share_access.post("shares/#{share_id}/action") do
           { access_list: nil }
         end.map_to('body.access_list', &share_rule_map)
       end
@@ -20,13 +31,13 @@ module ServiceLayer
 
       ################# INTERFACE METHODS ######################
       def create_share_rule(share_id, params)
-        elektron_shares.post("shares/#{share_id}/action") do
+        elektron_share_access.post("shares/#{share_id}/action") do
           { allow_access: params }
         end.body['access']
       end
 
       def delete_share_rule(share_id, rule_id)
-        elektron_shares.post("shares/#{share_id}/action") do
+        elektron_share_access.post("shares/#{share_id}/action") do
           { deny_access: { access_id: rule_id } }
         end
       end


### PR DESCRIPTION
only share access rules need to stay at older 2.44 because this api got
deprecated and would require a rework

most interesting new feature comes with 2.63:
"Added the possibility to attach security services to share networks in use.
Also, an attached security service can be replaced for another one of the same 'type'.
In order to support those operations a 'status' field was added in the share networks
as well as, a new property called 'security_service_update_support' was included
in the share networks and share servers.
Also new action APIs have been added to the share-networks endpoint:
'update_security_service', 'update_security_service_check' and 'add_security_service_check'."


TODO: 
- [ ] implement add_security_service_check: to check if it is okay to add a security service to a share network that is in use
- [ ] implement update_security_service: to change parameters of a security service that is associated to a certain share network, along with the pre check update_security_service_check