### PR TITLE
[keymanager]: workaround to fetch the NOT sanitized value of payload

### DIFF
--- a/plugins/key_manager/app/views/key_manager/secrets/show.html.haml
+++ b/plugins/key_manager/app/views/key_manager/secrets/show.html.haml
@@ -88,7 +88,7 @@
         .col-md-12
           %pre
             %code
-              = @secret.payload
+              = html_escape(@secret.attributes[:payload])              
     - else
       The Payload can not be displayed. To download the payload click following
       %a{href: plugin('key_manager').payload_secret_path(@secret.uuid)} Link.


### PR DESCRIPTION
Many plugins (Keymanager in this case is also included) use the `Core::ServiceLayer::Model` to map the JSON data from the api to a ruby&rails model. This models have no predefined methods for the attributes as it is used for different APIs without knowing of the data structure. To be able to reference the attributes per methods (ex: secret.payload == secret.attributes[:payload]) we make use of the custom method 'method_missing' to read the value. If the model method called has no parameters, so just read of attributes, the content of the attribute is sanitized using 'Rails::Html::FullSanitizer'.

This leads in 'edge' cases of losing of important information as it is with the payload of a secret:
ex: payload
```
bb<foo>aaa</ba>
```
was displayed as:
```
bbaaa
```

Fixes #1055 