### PR TITLE
Objectstore Roles

### DIFF
--- a/e2e/cypress/integration/member/instances.js
+++ b/e2e/cypress/integration/member/instances.js
@@ -86,7 +86,7 @@ describe("instances", () => {
     cy.contains('a','Create Snapshot').should('be.visible').then(($menu) => {
       cy.wrap($menu).click()
     })
-    cy.contains('you need the image_admin and swiftoperator role')
+    cy.contains('you need the image_admin and objectstore_admin role')
     cy.get('#mainModal button[type="button"]').click()
 
     cy.get('button.dropdown-toggle').click()

--- a/e2e/cypress/integration/member/shared_object_storage.js
+++ b/e2e/cypress/integration/member/shared_object_storage.js
@@ -7,10 +7,10 @@ describe("shared object storage", () => {
     )
   })
 
-  it("open object storage and see that I need admin or swiftoperator role", () => {
+  it("open object storage and see that I need one of the respective roles", () => {
     cy.visit(`/${Cypress.env("TEST_DOMAIN")}/test/object-storage/`)
     cy.contains('[data-test=page-title]','Object Storage')
-    cy.contains('Object Storage can only be used when your user account has the admin or swiftoperator role for this project.')
+    cy.contains('Object Storage can only be used when your user account has the admin or objectstore_admin or objectstore_viewer role for this project.')
   })
 
 })

--- a/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
+++ b/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
@@ -6,9 +6,9 @@
     %div{class: modal? ? 'modal-body' : ''}
       - if !@quota
         .alert.alert-danger
-          Server image snapshots are stored in your object storage. Your remaining object storage quota is not available. You can request storage 
+          Server image snapshots are stored in your object storage. Your remaining object storage quota is not available. You can request storage
           = link_to 'here', "#{plugin('resources').project_path()}#/storage", {target: "_blank"}
-      - if @free_capa <= 5120 
+      - if @free_capa <= 5120
         .alert.alert-warning
           Server image snapshots are stored in your object storage. Your remaining object storage quota is low. You can request more
           = link_to 'here', "#{plugin('resources').project_path()}#/storage", {target: "_blank"}
@@ -24,11 +24,11 @@
 - else
   %div{class: modal? ? 'modal-body' : ''}
     .alert.alert-info
-      %p 
+      %p
         Create snapshots not allowed. To create snapshots, you need the
         %code image_admin
         and
-        %code swiftoperator
-        role. Take a look to your  
+        %code objectstore_admin
+        role. Take a look to your
         = link_to "Profile", '#', data: { toggle: "modal", target: "#profile"}
         to find out which roles you have.

--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -20,6 +20,8 @@ ALLOWED_ROLES = %w[
   monitoring_viewer
   network_admin
   network_viewer
+  objectstore_admin
+  objectstore_viewer
   role_admin
   role_viewer
   reader

--- a/plugins/object_storage/app/views/object_storage/entry/howtoenable.html.haml
+++ b/plugins/object_storage/app/views/object_storage/entry/howtoenable.html.haml
@@ -5,7 +5,7 @@
   Object Storage can only be used when your user account has the
   %strong admin
   or
-  %strong swiftoperator
+  %strong objectstore_admin
   role for this project.
 
 = link_to 'Back', plugin('identity').project_path, class: 'btn btn-default'

--- a/plugins/object_storage/app/views/object_storage/entry/howtoenable.html.haml
+++ b/plugins/object_storage/app/views/object_storage/entry/howtoenable.html.haml
@@ -6,6 +6,8 @@
   %strong admin
   or
   %strong objectstore_admin
+  or
+  %strong objectstore_viewer
   role for this project.
 
 = link_to 'Back', plugin('identity').project_path, class: 'btn btn-default'


### PR DESCRIPTION
Allow new roles for Swift `objectstore_viewer` and `objectstore_admin` in Elektra.
Reference new role in description of services.