### PR TITLE
keppel: allow long label lines to break

### DIFF
--- a/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
@@ -39,14 +39,15 @@ const renderLabel = (key, value) => {
     </span>
   )
   if (isLink) {
-    return (
+    label = (
       <a key={key} href={value}>
         {label}
       </a>
     )
-  } else {
-    return label
   }
+  //the labels have `white-space:nowrap` inside, so some extra whitespace is
+  //required to allow long lines with lots of labels to break
+  return <React.Fragment>label{" "}</React.Fragment>
 }
 
 export default class ImageRow extends React.Component {


### PR DESCRIPTION
I currently don't have a functioning dev setup for Elektra, so I can't verify this myself. Can one of you please quickly check if this has the desired effect of allowing long label lines like these to break?

![image](https://user-images.githubusercontent.com/24696/177740425-7ba4abdf-26ea-45d0-ac5e-b9bc4a45cefe.png)

For testing purposes, I've provided a suitable image in qa-de-1 in the cc-demo/alpine repo.