### PR TITLE
[lbaas2] Fix member weight range. Member weights can be 0.

### DIFF
--- a/plugins/lbaas2/app/models/lbaas2/member.rb
+++ b/plugins/lbaas2/app/models/lbaas2/member.rb
@@ -3,8 +3,8 @@ module Lbaas2
     validates :name, presence: true
     validates :address, presence: true
     validates :weight, presence: true, inclusion: {
-      in: 1..256,
-      message: 'Choose a weight between 1 and 256'
+      in: 0..256,
+      message: 'Choose a weight between 0 and 256'
     }
     validates :protocol_port, presence: true, inclusion: {
       in: 1..65535,


### PR DESCRIPTION
Octavia pool members can have a weight between 0 and 256.