### PR TITLE
tools: update endpoint URL for limes rate-scrape-errors

### DIFF
--- a/plugins/tools/app/javascript/widgets/limes/actions/limes.js
+++ b/plugins/tools/app/javascript/widgets/limes/actions/limes.js
@@ -14,8 +14,11 @@ const fetchErrors = (errorType) => (dispatch) => {
     requestedAt: Date.now(),
   })
 
+  // rate scrape errors have moved from `/v1/admin/rate-scrape-errors` to `/rates/v1/admin/scrape-errors`
+  const errorsURL = errorType == "rate-scrape-errors" ? "/rates/v1/admin/scrape-errors" : `/v1/admin/${errorType}`
+
   return ajaxHelper
-    .get(`/v1/admin/${errorType}`)
+    .get(errorsURL)
     .then((response) => {
       const jsonKey = errorType.replace(/-/g, "_") //e.g. "asset-scrape-errors" -> "asset_scrape_errors"
       dispatch({


### PR DESCRIPTION
The old endpoint URL will go away probably next week.