### PR TITLE
pull Juno dependency by tag version instead of by "latest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jest-environment-jsdom": "^28.0.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^20.0.1",
-    "juno-ui-components": "https://github.com/sapcc/juno/releases/latest/download/juno-ui-components.tgz",
+    "juno-ui-components": "https://github.com/sapcc/juno/releases/download/v0_8_7/juno-ui-components.tgz",
     "postcss": "^8.4.18",
     "react-autocomplete-cli": "0.0.3",
     "react-test-renderer": "16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,9 +5454,9 @@ jsx-to-string@^1.4.0:
     json-stringify-pretty-compact "^1.0.1"
     react "^0.14.0"
 
-"juno-ui-components@https://github.com/sapcc/juno/releases/latest/download/juno-ui-components.tgz":
-  version "0.5.0"
-  resolved "https://github.com/sapcc/juno/releases/latest/download/juno-ui-components.tgz#86292abf690cb6214f5b904852268c8e3d756195"
+"juno-ui-components@https://github.com/sapcc/juno/releases/download/v0_8_7/juno-ui-components.tgz":
+  version "0.8.7"
+  resolved "https://github.com/sapcc/juno/releases/download/v0_8_7/juno-ui-components.tgz#ebf8ea3306514dc7a6448004bf3835d841a9028e"
 
 keycode@^2.1.2:
   version "2.2.1"


### PR DESCRIPTION
This way, it should not randomly break when a new Juno version is tagged.