### PR TITLE
[objectstore] cleanup deleted Swift roles

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -54,5 +54,4 @@ BLACKLISTED_ROLES = %w[
   resource_service
   cloud_objectstore_admin
   cloud_objectstore_viewer
-  swiftreseller
 ].freeze

--- a/plugins/identity/config/locales/en.yml
+++ b/plugins/identity/config/locales/en.yml
@@ -39,8 +39,6 @@ en:
     service: Service User
     sharedfilesystem_admin: Manila Administrator
     sharedfilesystem_viewer: Manila Read-Only
-    swiftoperator: Object Store Administrator
-    swiftreseller: Object Store Cloud Administrator
     objectstore_admin: Swift Administrator
     objectstore_viewer: Swift Read-Only
     volume_admin: Cinder Administrator

--- a/plugins/object_storage/config/policy.json
+++ b/plugins/object_storage/config/policy.json
@@ -1,5 +1,5 @@
 {
-  "object_storage_admin": "role:admin or role:swiftoperator or role:objectstore_admin",
+  "object_storage_admin": "role:admin or role:objectstore_admin",
   "object_storage_viewer": "role:objectstore_viewer or rule:object_storage_admin",
   "object_storage:entry_list": "not project_id:nil",
 

--- a/plugins/object_storage_ng/config/policy.json
+++ b/plugins/object_storage_ng/config/policy.json
@@ -1,5 +1,5 @@
 {
-  "object_storage_admin": "role:admin or role:swiftoperator",
+  "object_storage_admin": "role:admin or role:objectstore_admin",
   "object_storage_ng:entry_list": "not project_id:nil",
 
   "object_storage_ng:capabilities_list": "rule:object_storage_admin",


### PR DESCRIPTION
The roles `swiftoperator` and `swiftreseller` were purged from OpenStack identity. Cleanup in Elektra as well.