### PR TITLE
[lbaas] Make health monitor name attribute optional

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
@@ -199,7 +199,7 @@ const EditHealthMonitor = (props) => {
                 </p>
                 <Form.Errors errors={formErrors} />
 
-                <Form.ElementHorizontal label="Name" name="name" required>
+                <Form.ElementHorizontal label="Name" name="name">
                   <Form.Input elementType="input" type="text" name="name" />
                 </Form.ElementHorizontal>
 


### PR DESCRIPTION
When creating or editing a health monitor, the `Save` button can only be pressed if the `Name` field isn't empty.
However, [the name attribute for health monitors is optional](https://docs.openstack.org/api-ref/load-balancer/v2/index.html?expanded=create-health-monitor-detail#create-health-monitor).
This PR makes the `Name` field optional.

Note:
Health monitors without name can already be created via the CLI. Elektra then simply shows their ID instead of their name (under the label `Name/ID`). That means that Elektra already is (or at least has to be) able to handle this case. So the only thing that has to be changed is to make the `Name` field optional.