### PR TITLE
[lbaas] Health monitors: Fix mapping of max retries to API parameter

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
@@ -233,7 +233,7 @@ const EditHealthMonitor = (props) => {
                     type="number"
                     min="1"
                     max="10"
-                    name="max_retries"
+                    name="max_retries_down"
                   />
                   <span className="help-block">
                     <i className="fa fa-info-circle"></i>

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
@@ -151,7 +151,7 @@ const NewHealthMonitor = (props) => {
               type="number"
               min="1"
               max="10"
-              name="max_retries"
+              name="max_retries_down"
             />
             <span className="help-block">
               <i className="fa fa-info-circle"></i>


### PR DESCRIPTION
`max_retries` has been split up in [Octavia API](https://docs.openstack.org/api-ref/load-balancer/v2/index.html?expanded=create-health-monitor-detail#update-a-health-monitor) into `max_retries` and `max_retries_down`.
`max_retries_down` specifies the amount of retries for a HM before the pool member is considered down, while `max_retries` specifies the amount of retries for a HM before the pool member is considered up again.
We're only interested in the max retries before a member is down.