### PR TITLE
[lbaas] Health monitors: Remove Probe Timeout parameter

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
@@ -242,25 +242,6 @@ const EditHealthMonitor = (props) => {
                   </span>
                 </Form.ElementHorizontal>
 
-                <Form.ElementHorizontal
-                  label="Probe Timeout"
-                  name="timeout"
-                  required
-                >
-                  <Form.Input
-                    elementType="input"
-                    type="number"
-                    min="1"
-                    name="timeout"
-                  />
-                  <span className="help-block">
-                    <i className="fa fa-info-circle"></i>
-                    The time, in seconds, after which a single health check
-                    probe times out (fails). This value must be less than the
-                    interval value.
-                  </span>
-                </Form.ElementHorizontal>
-
                 <Form.ElementHorizontal label="Interval" name="delay" required>
                   <Form.Input
                     elementType="input"

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthmonitorDetails.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthmonitorDetails.jsx
@@ -114,12 +114,12 @@ const HealthmonitorDetails = ({ loadbalancerID, poolID, healthmonitor }) => {
       <div className="list-entry">
         <div className="row">
           <div className="col-md-12">
-            <b>Retries/Probe Timeout/Interval:</b>
+            <b>Retries/Interval:</b>
           </div>
         </div>
         <div className="row">
           <div className="col-md-12">
-            {healthmonitor.max_retries} / {healthmonitor.timeout} /{" "}
+            {healthmonitor.max_retries} /{" "}
             {healthmonitor.delay}
           </div>
         </div>

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
@@ -160,21 +160,6 @@ const NewHealthMonitor = (props) => {
             </span>
           </Form.ElementHorizontal>
 
-          <Form.ElementHorizontal label="Probe Timeout" name="timeout" required>
-            <Form.Input
-              elementType="input"
-              type="number"
-              min="1"
-              name="timeout"
-            />
-            <span className="help-block">
-              <i className="fa fa-info-circle"></i>
-              The time, in seconds, after which a single health check probe
-              times out (fails). This value must be less than the interval
-              value.
-            </span>
-          </Form.ElementHorizontal>
-
           <Form.ElementHorizontal label="Interval" name="delay" required>
             <Form.Input
               elementType="input"


### PR DESCRIPTION
Probe Timeout (`timeout` on the API) is not honored by the Octavia provider driver. This is intentional. I understand this might be confusing, so an optional detailed technical explanation can be found below.

PR #1175 might seem similar to this, but it's not; #1175 fixes a mapping between Elektra parameter name and API parameter name, while this PR removes an unused parameter entirely.

Optional detailed technical explanation:
Health monitors on the F5 backend only accept two parameters: `interval` and `timeout`. While the `interval` backend parameter has the same semantics as the `delay` Octavia API parameter (that is, the amount of seconds between probes), the `timeout` backend parameter has slightly different semantics than the Octavia API `timeout` parameter: While the `timeout` Octavia API parameter denotes the timeout *of a single probe*, the `timeout` backend parameter denotes the timeout `over all probes`. Therefore the `timeout` Octavia API parameter cannot be used here. Instead we calculate the `timeout` backend parameter (that is, the overall timeout) as the value of the `max_retries_down` Octavia API parameter (that is, the number of failing probes before the member is set to OFFLINE) multiplied by the `delay` Octavia API parameter (that is, the amount of seconds between probes) plus one spare second to give the last probe a chance to not run into a timeout. That calculation happens here: https://github.com/sapcc/octavia-f5-provider-driver/blob/stable/yoga-m3/octavia_f5/restclient/as3objects/monitor.py#L122