### PR TITLE
[lbaas] Fix wording: Members are marked as OFFLINE

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/EditHealthMonitor.jsx
@@ -194,7 +194,7 @@ const EditHealthMonitor = (props) => {
               <Modal.Body>
                 <p>
                   Checks the health of the pool members. Unhealthy members will
-                  be taken out of traffic schedule. Set's a load balancer to
+                  be taken out of traffic schedule. Sets a load balancer to
                   OFFLINE when all members are unhealthy.
                 </p>
                 <Form.Errors errors={formErrors} />
@@ -236,9 +236,9 @@ const EditHealthMonitor = (props) => {
                   />
                   <span className="help-block">
                     <i className="fa fa-info-circle"></i>
-                    The number of allowed check failures before changing the
-                    operating status of the member to ERROR. A valid value is
-                    from 1 to 10. The default is 3.
+                    The number of allowed check failures before marking the
+                    member as OFFLINE. A valid value is from 1 to 10.
+                    The default is 3.
                   </span>
                 </Form.ElementHorizontal>
 

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthMonitor.jsx
@@ -161,7 +161,7 @@ const HealthMonitor = ({ props, loadbalancerID }) => {
               <div className="healthmonitor subtable multiple-subtable-left">
                 <div className="display-flex multiple-subtable-header">
                   <h4>Health Monitor</h4>
-                  <HelpPopover text="Checks the health of the pool members. Unhealthy members will be taken out of traffic schedule. Set's a load balancer to OFFLINE when all members are unhealthy." />
+                  <HelpPopover text="Checks the health of the pool members. Unhealthy members will be taken out of traffic schedule. Sets a load balancer to OFFLINE when all members are unhealthy." />
                 </div>
 
                 <div className="toolbar searchToolbar">

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
@@ -119,7 +119,7 @@ const NewHealthMonitor = (props) => {
         <Modal.Body>
           <p>
             Checks the health of the pool members. Unhealthy members will be
-            taken out of traffic schedule. Set's a load balancer to OFFLINE when
+            taken out of traffic schedule. Sets a load balancer to OFFLINE when
             all members are unhealthy.
           </p>
           <Form.Errors errors={formErrors} />
@@ -151,9 +151,9 @@ const NewHealthMonitor = (props) => {
             />
             <span className="help-block">
               <i className="fa fa-info-circle"></i>
-              The number of allowed check failures before changing the operating
-              status of the member to ERROR. A valid value is from 1 to 10. The
-              default is 3.
+              The number of allowed check failures before marking the
+              member as OFFLINE. A valid value is from 1 to 10.
+              The default is 3.
             </span>
           </Form.ElementHorizontal>
 


### PR DESCRIPTION
Customers rarely use the dashboard and the CLI at the same time, so it's better to keep the wording true to the concepts used on the dashboard.

In #944 we decided to display members in state ERROR as OFFLINE. It is true that the operating_status of the members is set to ERROR in Octavia, but it is marked as OFFLINE in Elektra.