### PR TITLE
keppel: change sort order of the contains column to prefer images over tags

### DIFF
--- a/plugins/keppel/app/javascript/widgets/app/components/repositories/list.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/repositories/list.jsx
@@ -19,7 +19,7 @@ const columns = [
     label: "Contains",
     sortStrategy: "numeric",
     sortKey: (props) =>
-      (props.repo.tag_count || 0) + 0.00001 * (props.repo.manifest_count || 0),
+      (props.repo.manifest_count || 0) + 0.00001 * (props.repo.tag_count || 0),
   },
   {
     key: "size_bytes",


### PR DESCRIPTION
This is more logical since images are the first number in the row and also use at least a tiny amount of storage while tags are almost free.

@majewsky what do you think?