### PR TITLE
keppel: flip vulnerability status queries back to canonical names

### DIFF
--- a/plugins/keppel/app/javascript/widgets/app/components/images/details.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/images/details.jsx
@@ -96,7 +96,7 @@ export default class ImageDetailsModal extends React.Component {
           )
           if (
             manifestInfo &&
-            hasVulnReport(manifestInfo.trivy_vulnerability_status)
+            hasVulnReport(manifestInfo.vulnerability_status)
           ) {
             this.props.loadVulnsOnce()
           }
@@ -152,8 +152,8 @@ export default class ImageDetailsModal extends React.Component {
     const {
       media_type: mediaType,
       tags,
-      trivy_vulnerability_status: vulnStatus,
-      trivy_scan_error: vulnScanError,
+      vulnerability_status: vulnStatus,
+      vulnerability_scan_error: vulnScanError,
       gc_status: gcStatus,
     } = manifests.find((m) => m.digest == digest) || {}
 
@@ -348,7 +348,7 @@ export default class ImageDetailsModal extends React.Component {
           <tr key={`vulnstatus-${manifest.digest}`}>
             <th>Vulnerability status</th>
             <td>
-              {manifestInfo.trivy_vulnerability_status} ({detailsLink})
+              {manifestInfo.vulnerability_status} ({detailsLink})
             </td>
           </tr>
         )

--- a/plugins/keppel/app/javascript/widgets/app/components/images/list.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/images/list.jsx
@@ -39,9 +39,9 @@ const taggedColumns = [
     key: "vuln_status",
     label: "Vulnerability Status",
     sortStrategy: "numeric",
-    searchKey: (props) => props.data.trivy_vulnerability_status || "",
+    searchKey: (props) => props.data.vulnerability_status || "",
     sortKey: (props) =>
-      SEVERITY_ORDER[props.data.trivy_vulnerability_status || ""] || 0,
+      SEVERITY_ORDER[props.data.vulnerability_status || ""] || 0,
   },
   { key: "actions", label: "" },
 ]

--- a/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
@@ -100,7 +100,7 @@ export default class ImageRow extends React.Component {
       size_bytes: sizeBytes,
       pushed_at: pushedAtUnix,
       last_pulled_at: lastPulledAtUnix,
-      trivy_vulnerability_status: vulnerabilityStatus,
+      vulnerability_status: vulnerabilityStatus,
     } = this.props.data
 
     const labelKeys = Object.keys(labels || {}).sort()


### PR DESCRIPTION
These names serve Trivy data instead of Clair data now. The Trivy-specific names were only used to ensure a smooth migration, and are due for removal when the Clair integration goes away.

The only Trivy-specific name that remains is for the `trivy_report` endpoint, since Trivy reports truly have a different format than Clair reports.