### PR TITLE
Handle "^hv" for hypervisors in new instances

### DIFF
--- a/plugins/compute/app/views/compute/instances/new.html.haml
+++ b/plugins/compute/app/views/compute/instances/new.html.haml
@@ -89,7 +89,8 @@
       $(document).ready(function(){
         if ($('#server_flavor_id option:selected').text() != "Choose flavor") {
           if ($('#server_flavor_id option:selected').text().match(/^baremetal/) || 
-              $('#server_flavor_id option:selected').text().match(/^zh/) || 
+              $('#server_flavor_id option:selected').text().match(/^hv/) ||
+              $('#server_flavor_id option:selected').text().match(/^zh/) ||
               $('#server_flavor_id option:selected').text().match(/^zg/)) {
           // baremetal
             $('#baremetal_image_id_wrapper').removeClass('hidden');


### PR DESCRIPTION
The prefix `hv` is used to identify hypervisor flavors, which are also baremetal.