### PR TITLE
allow edit tag with compute-admin

### DIFF
--- a/plugins/compute/app/views/compute/instances/_item_actions.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item_actions.html.haml
@@ -18,7 +18,7 @@
         - if current_user.is_allowed?("compute:instance_update", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
           %li
             = link_to 'Edit Name', edit_instance_path(id: instance.id, action_from_show: show_view), data: { modal: true }
-        - if current_user.is_allowed?("context_is_compute_editor:", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
+        - if current_user.is_allowed?("compute:instance_update:", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
           %li
             = link_to 'Edit Tags', plugin('compute').tags_instance_path(id: instance.id), data: { modal: true}
         - if current_user.is_allowed?("compute:instance_update", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})


### PR DESCRIPTION
our customer recently noticed that without keystone admin role, he is not able to see "Edit Tag" button, which does not feels right. A common sense is anyone with compute_admin role should be able to edit tags. After examine the code, I propose the change in this PR, please kindly review.

![image](https://github.com/sapcc/elektra/assets/20290937/f5d0e88e-9bb1-4d2f-a4e4-1c4c71dac69d)
![image](https://github.com/sapcc/elektra/assets/20290937/1aba5943-d2ce-491a-a5f3-509e58fc1975)
