### PR TITLE
[octavia] add a "Max Retries" note to a health monitor UI

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthmonitorDetails.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/HealthmonitorDetails.jsx
@@ -114,7 +114,7 @@ const HealthmonitorDetails = ({ loadbalancerID, poolID, healthmonitor }) => {
       <div className="list-entry">
         <div className="row">
           <div className="col-md-12">
-            <b>Max Retries/Interval:</b>
+            <b>Max Retries Down/Interval:</b>
           </div>
         </div>
         <div className="row">

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
@@ -141,7 +141,10 @@ const NewHealthMonitor = (props) => {
             </span>
           </Form.ElementHorizontal>
 
-          <Form.ElementHorizontal label="Max Retries Down" name="max_retries_down">
+          <Form.ElementHorizontal
+            label="Max Retries Down"
+            name="max_retries_down"
+          >
             <Form.Input
               elementType="input"
               type="number"
@@ -152,9 +155,9 @@ const NewHealthMonitor = (props) => {
             <span className="help-block">
               <i className="fa fa-info-circle"></i>
               The number of allowed check failures before marking the member as
-              OFFLINE. A valid value is from 1 to 10. The default is 3.
-
-              <b>Note</b>: This parameter differs from the Octavia "Max Retries", which is not supported in CCloud environment.
+              OFFLINE. A valid value is from 1 to 10. The default is 3.{" "}
+              <b>Note</b>: This parameter differs from the Octavia "Max
+              Retries", which is not supported in CCloud environment.
             </span>
           </Form.ElementHorizontal>
 

--- a/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/components/healthmonitor/NewHealthMonitor.jsx
@@ -141,7 +141,7 @@ const NewHealthMonitor = (props) => {
             </span>
           </Form.ElementHorizontal>
 
-          <Form.ElementHorizontal label="Max Retries" name="max_retries_down">
+          <Form.ElementHorizontal label="Max Retries Down" name="max_retries_down">
             <Form.Input
               elementType="input"
               type="number"
@@ -153,6 +153,8 @@ const NewHealthMonitor = (props) => {
               <i className="fa fa-info-circle"></i>
               The number of allowed check failures before marking the member as
               OFFLINE. A valid value is from 1 to 10. The default is 3.
+
+              <b>Note</b>: This parameter differs from the Octavia "Max Retries", which is not supported in CCloud environment.
             </span>
           </Form.ElementHorizontal>
 


### PR DESCRIPTION
A follow-up for the #1175 to avoid a potential user confusion.