### PR TITLE
[Resources] Distinguish cluster UI naming

### DIFF
--- a/config/navigations/cloud_admin_navigation.rb
+++ b/config/navigations/cloud_admin_navigation.rb
@@ -92,7 +92,7 @@ SimpleNavigation::Configuration.run do |navigation|
                       },
                       if: -> { services.available?(:resources) && plugin_available?(:resources) }
       ccadmin_nav.item :resources,
-                      capture { concat "Resource Management "; concat content_tag(:span, "NEW", class:"label label-info")},
+                      capture { concat "Cluster Resources Administration "; concat content_tag(:span, "NEW", class:"label label-info")},
                       -> {
                         plugin("resources").v2_cluster_path(cluster_id: "current")
                       },


### PR DESCRIPTION
Cluster UI: Rename `Resource Management` to `Cluster Resources Administration`.
The previous naming caused confusion for the support team, because it collided with the project level naming of the UI.