### PR TITLE
maillog-ui (juno app) view added as tab to email-service

### DIFF
--- a/plugins/email_service/app/controllers/email_service/maillog_controller.rb
+++ b/plugins/email_service/app/controllers/email_service/maillog_controller.rb
@@ -1,0 +1,10 @@
+module EmailService
+  class MaillogController < ::EmailService::ApplicationController
+    authorization_context 'email_service'
+    authorization_required
+
+    def index
+
+    end
+  end
+end

--- a/plugins/email_service/app/views/email_service/maillog/index.html.haml
+++ b/plugins/email_service/app/views/email_service/maillog/index.html.haml
@@ -1,0 +1,19 @@
+=content_for :main_toolbar do
+  Email Service - AWS SES (Cronus)
+= render partial: 'email_service/shared/nav', formats: :html, locals: {pane: 'maillog'}
+
+.tab-content
+  .tab-pane.active{role:"tabpanel", id:"maillog-pane"}
+    :plain
+      <script
+        defer
+        src="https://assets.juno.#{qa? ? 'qa-de-1' : 'global'}.cloud.sap/apps/widget-loader@latest/build/app.js"
+        data-name="maillog"
+        data-version="latest"
+        data-props-get-token-func-name="_getCurrentToken"
+        data-props-theme="theme-light"
+        data-props-endpoint="https://maillog.#{current_region}.cloud.sap"
+        data-props-embedded="true"
+        data-props-project="#{@scoped_project_id}">
+      </script>
+    

--- a/plugins/email_service/app/views/email_service/shared/_nav.html.haml
+++ b/plugins/email_service/app/views/email_service/shared/_nav.html.haml
@@ -9,3 +9,4 @@
   %li{class: ('active' if pane == 'ec2'), role: "presentation"}= link_to 'EC2 Credentials', plugin('email_service').ec2_credentials_path, aria: {controls:"settings-pane"}, role: "tab"
   %li{class: ('active' if pane == 'settings'), role: "presentation"}= link_to 'Settings', plugin('email_service').settings_path, aria: {controls:"settings-pane"}, role: "tab"
   %li{class: ('active' if pane == 'suppression-list'), role: "presentation"}= link_to 'Suppression List', plugin('email_service').suppression_lists_path, aria: {controls:"suppression-list-pane"}, role: "tab"
+  %li{class: ('active' if pane == 'maillog'), role: "presentation"}= link_to 'Maillog', plugin('email_service').maillog_path, aria: {controls:"maillog-pane"}, role: "tab"

--- a/plugins/email_service/config/routes.rb
+++ b/plugins/email_service/config/routes.rb
@@ -30,4 +30,6 @@ EmailService::Engine.routes.draw do
   get '/web/test' => 'web#test', :as => :test
 
   resources :suppression_lists, only: %i[index show new create destroy]
+  get '/maillog' => 'maillog#index', :as => :maillog
+
 end


### PR DESCRIPTION
A view for maillog UI added as a tab to Email-service plugin.
maillog-ui is a juno app - https://github.wdf.sap.corp/cronus/maillog-ui