### PR TITLE
Adjusting cluster admin UI link reference

### DIFF
--- a/config/navigations/cloud_admin_navigation.rb
+++ b/config/navigations/cloud_admin_navigation.rb
@@ -86,11 +86,11 @@ SimpleNavigation::Configuration.run do |navigation|
                       plugin("inquiry").admin_inquiries_path,
                       if: -> { plugin_available?(:inquiry) }
       ccadmin_nav.item :resources,
-                      capture { concat "Cluster Resources Administration ";},
+                      "Cluster Resources Administration",
                       -> {
                         plugin("resources").v2_cluster_path(cluster_id: "current")
                       },
-                      if: -> { services.available?(:resources) && plugin_available?(:resources) }
+                      if: -> { plugin_available?(:resources) }
       ccadmin_nav.item :flavors,
                       "Manage Flavors",
                       -> { plugin("compute").flavors_path },


### PR DESCRIPTION
The cloud admin UI was not present in elektra. The cloud admin nav item still had a deprecated service check to the old resource UI. I changed this to an plugin availability check, so that the admin UI actually shows up in the UI.