### PR TITLE
[shared_filesystem_storage] correct replica actions

### DIFF
--- a/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/replica.rb
+++ b/plugins/shared_filesystem_storage/app/services/service_layer/shared_filesystem_storage_services/replica.rb
@@ -60,7 +60,7 @@ module ServiceLayer
 
       def resync_replica(id)
         elektron_share_replicas
-          .post("share-replicas/#{id}/action") { { resync: true } }
+          .post("share-replicas/#{id}/action") { { resync: nil } }
           .body[
           "share_replica"
         ]
@@ -69,7 +69,7 @@ module ServiceLayer
       def promote_replica(id)
         # byebug
         elektron_share_replicas
-          .post("share-replicas/#{id}/action") { { promote: true } }
+          .post("share-replicas/#{id}/action") { { promote: nil } }
           .body[
           "share_replica"
         ]


### PR DESCRIPTION
according to API spec the values should be `null`, not `true`

e.g. see https://docs.openstack.org/api-ref/shared-file-system/#resync-share-replica

promote received additional optional arguments (like quiesce_wait_time see https://docs.openstack.org/api-ref/shared-file-system/#promote-share-replica) and sending true is being rejected now by the manila api validation