### PR TITLE
fix(masterdata): do not show no method error if billing API is down

### DIFF
--- a/plugins/masterdata_cockpit/app/views/masterdata_cockpit/project_masterdata/_project_details.html.haml
+++ b/plugins/masterdata_cockpit/app/views/masterdata_cockpit/project_masterdata/_project_details.html.haml
@@ -3,14 +3,11 @@
     .col-sm-4.details-label
       Name
     .col-sm-8.details-value
-      = @project.name
+      = @project&.name
   .row
     .col-sm-4.details-label
       Description
     .col-sm-8.details-value
       =# use active project here because at the moment masterdata api supports max. 255 chars
       %span.description
-        - if @project.description
-          = @project.description
-        - else
-          \-
+        = @project&.description || '-'


### PR DESCRIPTION
## Fix `NoMethodError` Bug in Masterdata

This PR addresses a `NoMethodError` bug in the Masterdata plugin. The issue occurs when the billing API fails to respond or returns an error, causing the controller's flow to be interrupted. As a result, the method responsible for fetching the project data is never executed, leading to the standard Rails error "NoMethodError" being displayed in the view.

## Fix:
The issue has been resolved by using the safe navigation operator (`&.`), which gracefully handles `nil` values without raising an exception. Specifically, `project.name` has been replaced with `project&.name`, ensuring that the view does not break when `project` is `nil`.

This fix ensures a smoother user experience by preventing unexpected errors and maintaining the intended flow in the application.