### PR TITLE
fix(compute): load floating ip to get the id

### DIFF
--- a/plugins/compute/app/helpers/compute/instances_helper.rb
+++ b/plugins/compute/app/helpers/compute/instances_helper.rb
@@ -304,6 +304,7 @@ module Compute
         # puts "############ one to many ip-fip relation found - use project_floating_ips ###########"
         @project_floating_ips = services.networking.project_floating_ips(@scoped_project_id)
       end
+      # byebug
       instance.ip_maps(@project_floating_ips)
     end
 

--- a/plugins/compute/app/models/compute/server.rb
+++ b/plugins/compute/app/models/compute/server.rb
@@ -229,7 +229,7 @@ module Compute
       server_floating_ips_and_network = {}
       server_fixed_ips = []
       server_fixed_ips_and_network = {}
-      
+      # byebug
       # extract the fips and fixed ips for the server
       addresses.each do |network_name, ips|
         ips.each do |ip|
@@ -262,6 +262,10 @@ module Compute
           # check if there is only one floating IP and one fixed IP
           if fips.length == 1 && server_fixed_ips_and_network[network_name].length == 1
             # if there is only one floating IP and one fixed IP, we can assume that the floating IP is associated with the fixed IP
+            
+            # load the floating IP object to access the floating IP ID
+            floating_ip = @service.service_manager.networking.floating_ips({floating_ip_address: fips.first}).first
+            # byebug
             fip_ip_one_to_one_maps << 
               {
                 "fixed" => {
@@ -271,6 +275,8 @@ module Compute
                 "floating" => {
                   "addr" => fips.first,
                   "network_name" => network_name,
+                  # add floating IP ID to the map
+                  "id" => floating_ip&.id,
                 },
               }
           end


### PR DESCRIPTION
## Fix Floating IP Detachment and View Update Errors

This PR addresses two key issues that emerged after reworking the process of attaching multiple fixed and floating IPs to an instance:

1.	Floating IP Detachment Error: The detachment process for floating IPs stopped functioning because the Floating IP was missing its ID in the relevant map. This ID is crucial for successfully detaching the Floating IP. The issue has been resolved by ensuring the ID is correctly included.
2.	View Update Errors: The view was not updating correctly after attaching or detaching a Floating IP due to a delay. Even after reloading, the changes were not immediately reflected in the instance. This was fixed by manually adding or removing the floating IP entry in the instance addresses, ensuring the view updates as expected.