### PR TITLE
chore(core): add stale issue and pr workflow

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          exempt-issue-labels: neverstale
+          exempt-pr-labels: WIP


### PR DESCRIPTION
# Summary

This PR adds a workflow that automatically closes stale issues and PRs. It uses [this workflow](https://github.com/marketplace/actions/close-stale-issues) from GitHub marketplace. I have kept most default settings. That means that after 60 days an issue or PR will be marked as stale if there hasn't been any update. After an issue or pr has been marked as stale there is a grace period of 7 days. If there still hasn't been an update after 7 days then the issue is closed.

Changes to the default:
* issues with the label `neverstale` are ignored by the workflow
* PRs with label `WIP` are ignored by the workflow

# Changes Made

- add close stale issues and prs workflow

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
