### PR TITLE
fix(security groups): handle 500 items limit

### DIFF
--- a/plugins/networking/app/controllers/networking/security_groups_controller.rb
+++ b/plugins/networking/app/controllers/networking/security_groups_controller.rb
@@ -7,10 +7,20 @@ module Networking
     authorization_required
 
     def index
-      security_groups = services.networking.security_groups
-
-      # byebug
-      render json: { security_groups: security_groups }
+      # this function is called when the user opens the security groups page and the ajax call is made
+      all_security_groups = []
+      # get the first 500 security groups
+      security_groups = services.networking.security_groups()
+      all_security_groups = security_groups
+      # get all security groups until the limit of 500 is reached
+      while security_groups.length == 500
+        marker = security_groups.last.id
+        security_groups = services.networking.security_groups({marker: marker})
+        all_security_groups += security_groups
+      end
+      # puts "######### all_security_groups: #{all_security_groups.length}"
+      # render the security groups as json to consume them in the react frontend
+      render json: { security_groups: all_security_groups }
     rescue Elektron::Errors::ApiResponse => e
       render json: { errors: e.message }, status: e.code
     end

--- a/plugins/networking/app/javascript/widgets/security_groups/components/security_groups/list.jsx
+++ b/plugins/networking/app/javascript/widgets/security_groups/components/security_groups/list.jsx
@@ -1,16 +1,14 @@
 /* eslint-disable no-undef */
-import { Link } from "react-router-dom"
 import { DefeatableLink } from "lib/components/defeatable_link"
 import { SearchField } from "lib/components/search_field"
 import SecurityGroupItem from "./item"
-import { AjaxPaginate } from "lib/components/ajax_paginate"
 import { pluginAjaxHelper } from "lib/ajax_helper"
 const ajaxHelper = pluginAjaxHelper("networking")
 import React from "react"
 
 const List = ({ loadSecurityGroupsOnce, securityGroups, handleDelete }) => {
   const [searchTerm, setSearchTerm] = React.useState("")
-  const { isFetching, hasNext, loadNext } = securityGroups
+  const { isFetching } = securityGroups
 
   const [cachedProjects, setCachedProjects] = React.useState()
 
@@ -70,13 +68,21 @@ const List = ({ loadSecurityGroupsOnce, securityGroups, handleDelete }) => {
                     input field will show all currently loaded items."
           />
         )}
+        <div style={{ paddingLeft: "10px" }}>
+          Security Groups found:{filteredItems.length}
+        </div>
 
         <div className="main-buttons">
-          {policy.isAllowed("networking:security_group_create") && (
-            <DefeatableLink to="/new" className="btn btn-primary">
-              New Security Group
-            </DefeatableLink>
-          )}
+          {policy.isAllowed("networking:security_group_create") &&
+            (isFetching ? (
+              <DefeatableLink to="/new" className="btn btn-primary" disabled>
+                New Security Group
+              </DefeatableLink>
+            ) : (
+              <DefeatableLink to="/new" className="btn btn-primary">
+                New Security Group
+              </DefeatableLink>
+            ))}
         </div>
       </div>
 

--- a/plugins/networking/app/services/service_layer/networking_services/security_group.rb
+++ b/plugins/networking/app/services/service_layer/networking_services/security_group.rb
@@ -9,6 +9,7 @@ module ServiceLayer
       end
 
       def security_groups(filter = {})
+        # https://docs.openstack.org/api-ref/network/v2/index.html#list-security-groups
         elektron_networking.get("security-groups", filter).map_to(
           "body.security_groups",
           &security_group_map
@@ -20,6 +21,7 @@ module ServiceLayer
       end
 
       def find_security_group!(id)
+        # https://docs.openstack.org/api-ref/network/v2/index.html#show-security-group
         return nil unless id
         elektron_networking.get("security-groups/#{id}").map_to(
           "body.security_group",
@@ -35,6 +37,7 @@ module ServiceLayer
 
       ########### Model Interface ###################
       def create_security_group(attributes)
+        # https://docs.openstack.org/api-ref/network/v2/index.html#create-security-group-default-rule
         elektron_networking
           .post("security-groups") { { security_group: attributes } }
           .body[
@@ -43,6 +46,7 @@ module ServiceLayer
       end
 
       def update_security_group(id, attributes)
+        # https://docs.openstack.org/api-ref/network/v2/index.html#update-security-group
         elektron_networking
           .put("security-groups/#{id}") { { security_group: attributes } }
           .body[
@@ -51,6 +55,7 @@ module ServiceLayer
       end
 
       def delete_security_group(id)
+        # https://docs.openstack.org/api-ref/network/v2/index.html#delete-security-group
         elektron_networking.delete("security-groups/#{id}")
       end
     end


### PR DESCRIPTION
# Summary

will load all security groups beyond the 500 items limit

this is a fix that works without larger rewrite of the code, just use the marker option to load all items on server side, than the user can use the search on client side to find the item. 

But it comes with a grain of salt 

1. it can be a problem if more than 1 or 2k Security Groups are found
2. the Api is not that fast to deliver the items if the count is beyond 500 

# Changes Made

- adjust the loading funktion in the controller to load all security groups with marker if more than 500 are found
- adjust view to show the count of all security groups
- disable the new button if loading is in progress
- add api docu to service layer

# Related Issues

- Issue 1: #1395 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
