### PR TITLE
remove everything that needs cloud_resource_admin permissions

### DIFF
--- a/plugins/dns_service/app/controllers/concerns/create_zones_helper.rb
+++ b/plugins/dns_service/app/controllers/concerns/create_zones_helper.rb
@@ -10,10 +10,6 @@ module CreateZonesHelper
       zone.errors.add("Error", "Zone already existing")
       return zone
     else
-      adjust_resource_limits(
-        domain_id, project_id, target_project&.domain_id, target_project&.id
-      )
-
       pool = cloud_admin.dns_service.find_pool(attributes[:domain_pool])
       pool_attrs = pool.read("attributes")
       zone = services.dns_service.new_zone(attributes)
@@ -72,45 +68,6 @@ module CreateZonesHelper
       requested_parent_zone_name = requested_parent_zone_name.partition(".").last
     end
   end
-  
-  # this method checks the zone and recordset limits of the project
-  # and increases them if needed.
-  # If target project is different from this project, the zone has 
-  # to be created in the target project and then transferred to this project.
-  # For this, the limitis for zone of target project and this project should be checked
-  # and increased if needed. Additionally, the recordset limits of this project 
-  # should be checked and increased if needed. 
-  def adjust_resource_limits(
-    source_domain_id,
-    source_project_id,
-    target_domain_id,
-    target_project_id)
-    # first, get the latests state of the limes data for this project
-    update_limes_data(source_domain_id,source_project_id)
-    
-    # update zone limits for this project if needed
-    check_and_increase_quota(
-      source_domain_id,
-      source_project_id, 
-      "zones",
-      2
-    )
-    # update recordset limits for this project if needed
-    check_and_increase_quota(
-      source_domain_id,
-      source_project_id, 
-      "recordsets",
-      2,
-    )
-
-    # update zone limits for destination project if needed
-    if target_project_id.present? && (target_project_id != source_project_id)
-      # first, get the latests state of the limes data for target project
-      update_limes_data(target_domain_id, target_project_id)  
-      # check and increase zone quota for destination project
-      check_and_increase_quota(target_domain_id, target_project_id, "zones")
-    end
-  end
 
   def transfer_zone_if_needed(zone, source_project_id, target_project_id)
     if target_project_id != source_project_id
@@ -133,82 +90,5 @@ module CreateZonesHelper
       # catch errors for transfer zone request
       return zone_transfer_request.errors
     end
-  end
-
-  def check_and_increase_quota(domain_id, project_id, resource, increase = 1)
-    # get dns quota for resource and target project
-    dns_resource =
-      cloud_admin
-        .resource_management
-        .find_project(domain_id, project_id, service: "dns", resource: resource)
-        .resources
-        .first or raise ActiveRecord::RecordNotFound
-
-    # NOTE: dns_resource.usable_quota is quota + burst
-    if dns_resource.quota == 0 || dns_resource.quota <= dns_resource.usage
-      if dns_resource.quota < dns_resource.usage
-        puts "INFO: for project #{project_id} in domain #{domain_id} the usable quota is smaller than usage! Set quota for resource #{resource} to #{dns_resource.usage + increase}"
-        # special case if usable quota is smaller than usage than adjust new quota to usage plus increase value
-        dns_resource.quota = dns_resource.usage + increase
-      else
-        puts "INFO: increase quota for project #{project_id} in domain #{domain_id} for resource #{resource} by #{increase}"
-        # standard increase quota plus increase value
-        dns_resource.quota += increase
-      end
-      unless dns_resource.save
-        # catch error for automatic quota adjustment
-        dns_resource.errors.each { |k, m| @zone_request.errors.add(k, m) }
-      else
-        puts "INFO: wait 3s to be sure that limes could set the quota correctly"
-        sleep 3
-      end
-    end
-  end
-
-  def update_limes_data(domain_id, project_id)
-    # get last scraped time
-    current_timestamp = Time.now.to_i
-      # update limes data synchronously
-      cloud_admin.resource_management.sync_project_asynchronously(
-        domain_id,
-        project_id,
-      )
-      
-    scraped_at = current_timestamp
-    retry_count = 1
-    while scraped_at.to_i <= current_timestamp && retry_count <= 10
-      puts "INFO: update limes data for project #{project_id} in domain #{domain_id}, wait 2s to check that update is done"
-      sleep 3
-      scraped_at =
-        begin
-          cloud_admin
-            .resource_management
-            .find_project(domain_id, project_id, service: "dns", resource: "zones")
-            .services
-            .first
-            .scraped_at
-        rescue StandardError
-          0
-        end
-      puts "INFO: check limes update. retry_count: #{retry_count}; scraped_at_old: #{current_timestamp}; scraped_at_new: #{scraped_at.to_i}"
-      retry_count += 1
-    end
-  end
-
-  def get_zone_resource
-    cloud_admin
-      .resource_management
-      .find_project(@scoped_domain_id, @scoped_project_id, service: "dns", resource: "zones",)
-      .resources
-      .first or raise ActiveRecord::RecordNotFound
-  end
-
-  def get_recordset_resource
-    @recordset_resource =
-      cloud_admin
-        .resource_management
-        .find_project(@scoped_domain_id, @scoped_project_id, service: "dns", resource: "recordsets")
-        .resources
-        .first or raise ActiveRecord::RecordNotFound
   end
 end

--- a/plugins/dns_service/app/controllers/dns_service/create_zone_wizard_controller.rb
+++ b/plugins/dns_service/app/controllers/dns_service/create_zone_wizard_controller.rb
@@ -9,35 +9,6 @@ module DnsService
       payload = @inquiry.payload
       @zone_request.attributes = payload
       @pool = load_pool(@zone_request.domain_pool)
-
-      if @inquiry
-        scraped_at =
-          begin
-            cloud_admin
-              .resource_management
-              .find_project(
-                @inquiry.domain_id,
-                @inquiry.project_id,
-                service: "dns",
-                resource: "zones",
-              )
-              .services
-              .first
-              .scraped_at
-          rescue StandardError
-            0
-          end
-
-        # sync if last sync was more than 5 minutes ago
-        if (Time.now.to_i - scraped_at.to_i) > 300
-          Thread.new do
-            cloud_admin.resource_management.sync_project_asynchronously(
-              @inquiry.domain_id,
-              @inquiry.project_id,
-            )
-          end
-        end
-      end
     end
 
     def create

--- a/plugins/dns_service/app/controllers/dns_service/request_zone_wizard_controller.rb
+++ b/plugins/dns_service/app/controllers/dns_service/request_zone_wizard_controller.rb
@@ -9,9 +9,6 @@ module DnsService
       @zone_request = ::DnsService::ZoneRequest.new(nil)
       @pools = cloud_admin.dns_service.pools[:items]
 
-      @zone_resource = get_zone_resource
-      @recordset_resource = get_recordset_resource
-
       # this needs to be removed when migration is done
       @pools.reject! do |pool|
         pool.attributes["attributes"]["label"] == "New External SAP Hosted Zone"
@@ -66,8 +63,6 @@ module DnsService
         render template: "dns_service/request_zone_wizard/create", formats: :js
       else
         @pools = cloud_admin.dns_service.pools[:items]
-        @zone_resource = get_zone_resource
-        @recordset_resource = get_recordset_resource
         render action: :new
       end
     end

--- a/plugins/identity/app/controllers/identity/domains/create_wizard_controller.rb
+++ b/plugins/identity/app/controllers/identity/domains/create_wizard_controller.rb
@@ -28,19 +28,6 @@ module Identity
         if @project.save
           audit_logger.info(current_user, "has created", @project)
 
-          if services.available?(:resource_management)
-            # discover newly created projects
-            # use cloud_admin because domain resource admin role is required for this call
-            # rescue in case an exception happens so that the rest of the action is performed
-            begin
-              cloud_admin.resource_management.discover_projects(
-                @scoped_domain_id,
-              )
-            rescue StandardError
-              nil
-            end
-          end
-
           flash.now[:notice] = "Project #{@project.name} successfully created."
           if @inquiry
             if @inquiry.requester && @inquiry.requester.uid


### PR DESCRIPTION
* The whole DNS quota-editing thing has been either superfluous or broken since May, when Limes stopped supporting quota editing.
* After this, the only thing that's left is to explicitly sync projects after a new project is created. This is something that Limes does on its own, anyway; the explicit sync is just to shorten the wait time from max. 3 minutes to a few seconds. Since we don't commonly have domain admins create projects that need to be ready to use by the same person immediately afterwards, I think we can live with the max. 3 minutes delay.

If you approve this, please also merge https://github.com/sapcc/helm-charts/pull/7065.