### PR TITLE
remove all remaining usages of the old @quota_data mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,36 +375,6 @@ Available attributes:
 - `exception_id` (default is request uuid)
 - `warning` (default false. If true a warning page is rendered instead of error page)
 
-## Display Quota Data
-
-If the variable `@quota_data` is set the view will display all data inside this variable.
-
-### How to set @quota_data
-
-This will load quota data from the database and update the usage attribute.
-
-```ruby
-@quota_data = services.resource_management.quota_data(
-  current_user.domain_id || current_user.project_domain_id,
-  current_user.project_id,[
-  {service_type: 'compute', resource_name: 'instances', usage: @instances.length},
-  {service_type: 'compute', resource_name: 'cores', usage: cores},
-  {service_type: 'compute', resource_name: 'ram', usage: ram}
-])
-```
-
-Same example but without updating the usage attribute. It just loads the values from the database. Note that the database is not always up to date.
-
-```ruby
-@quota_data = services.resource_management.quota_data(
-  current_user.domain_id || current_user.project_domain_id,
-  current_user.project_id,[
-  {service_type: 'compute', resource_name: 'instances'},
-  {service_type: 'compute', resource_name: 'cores'},
-  {service_type: 'compute', resource_name: 'ram'}
-])
-```
-
 ## Pagination
 
 ### Controller

--- a/app/views/layouts/modal.html.haml
+++ b/app/views/layouts/modal.html.haml
@@ -11,11 +11,6 @@
           - else
             = "#{action_name.capitalize} #{controller.controller_name.singularize.humanize}"
 
-        - if @quota_data and @quota_data.length>0
-          .info-text
-            %i.monitoring-icon
-            = "Remaining Quota: #{@quota_data.collect(&:available_as_display_string).join(', ')}"
-
       = yield
 
 = yield :javascripts

--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -127,21 +127,6 @@ module Compute
     end
 
     def new
-      # get usage from db
-      @quota_data = []
-      if current_user.is_allowed?("access_to_project")
-        @quota_data =
-          services.resource_management.quota_data(
-            current_user.domain_id || current_user.project_domain_id,
-            current_user.project_id,
-            [
-              { service_type: :compute, resource_name: :instances },
-              { service_type: :compute, resource_name: :cores },
-              { service_type: :compute, resource_name: :ram },
-            ],
-          )
-      end
-
       @instance = services.compute.new_server
       @flavors = services.compute.flavors
       @images = services.image.all_images
@@ -682,15 +667,6 @@ module Compute
     end
 
     def new_snapshot
-      @quota_data =
-        services.resource_management.quota_data(
-          @scoped_domain_id,
-          @scoped_project_id,
-          [{ service_type: :"object-store", resource_name: :capacity }],
-        )
-      @quota = @quota_data.select { |q| q.name == :capacity }.first
-      @free_capa = @quota.quota - @quota.usage
-      @free_capa = @free_capa / 1024 / 1024
       @action_from_show = params[:action_from_show] == "true" || false
     end
 

--- a/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
+++ b/plugins/compute/app/views/compute/instances/new_snapshot.html.haml
@@ -4,14 +4,6 @@
 - if current_user.is_allowed?("compute:image_admin") && current_user.is_allowed?("object_storage:container_create")
   = simple_form_for :snapshot, url: plugin('compute').create_image_instance_path(id:params[:id], action_from_show:@action_from_show), method: :put, remote: request.xhr?, html: {data: {modal: true}, class: 'form-horizontal' }, wrapper: :horizontal_form do |f|
     %div{class: modal? ? 'modal-body' : ''}
-      - if !@quota
-        .alert.alert-danger
-          Server image snapshots are stored in your object storage. Your remaining object storage quota is not available. You can request storage
-          = link_to 'here', "#{plugin('resources').v2_project_path()}#/storage", {target: "_blank"}
-      - if @free_capa <= 5120
-        .alert.alert-warning
-          Server image snapshots are stored in your object storage. Your remaining object storage quota is low. You can request more
-          = link_to 'here', "#{plugin('resources').v2_project_path()}#/storage", {target: "_blank"}
       = f.input :name, icon_hint: 'A snapshot is an image which preserves the disk state of a running instance.'
 
     %div.buttons{class: modal? ? 'modal-footer' : ''}
@@ -19,8 +11,7 @@
         %button.btn.btn-default{type:"button", data: {dismiss:"modal"}, aria: {label: "Cancel"}} Cancel
       - else
         = link_to "Cancel", instances_url(), class: 'btn btn-default'
-      - if @quota
-        = button_tag "Create Snapshot", { class: 'btn btn-primary pull-right', data: { disable_with: "Please wait..." } }
+      = button_tag "Create Snapshot", { class: 'btn btn-primary pull-right', data: { disable_with: "Please wait..." } }
 - else
   %div{class: modal? ? 'modal-body' : ''}
     .alert.alert-info

--- a/plugins/compute/spec/controllers/instances_controller_spec.rb
+++ b/plugins/compute/spec/controllers/instances_controller_spec.rb
@@ -33,10 +33,6 @@ describe Compute::InstancesController, type: :controller do
     allow_any_instance_of(ServiceLayer::ComputeService).to receive(
       :usage,
     ).and_return(double("usage", instances: 1, ram: 2, cores: 4))
-
-    allow_any_instance_of(ServiceLayer::ResourceManagementService).to receive(
-      :quota_data,
-    ).and_return([])
   end
 
   describe "GET 'index'" do

--- a/plugins/networking/app/controllers/networking/routers_controller.rb
+++ b/plugins/networking/app/controllers/networking/routers_controller.rb
@@ -8,7 +8,6 @@ module Networking
     def index
       ################# NEW
       @routers = []
-      @quota_data = []
 
       if current_user.is_allowed?("context_is_cloud_network_admin")
         @routers =
@@ -139,15 +138,6 @@ module Networking
     end
 
     def new
-      @quota_data = []
-      if current_user.is_allowed?("access_to_project")
-        @quota_data =
-          services.resource_management.quota_data(
-            current_user.domain_id || current_user.project_domain_id,
-            current_user.project_id,
-            [{ service_type: :network, resource_name: :routers }],
-          )
-      end
       # build new router object (no api call done yet!)
       @router = services.networking.new_router("admin_state_up" => true)
     end

--- a/plugins/networking/app/controllers/networking/widgets_controller.rb
+++ b/plugins/networking/app/controllers/networking/widgets_controller.rb
@@ -11,18 +11,6 @@ module Networking
     end
 
     def security_groups
-      @quota_data = []
-      return unless current_user.is_allowed?("access_to_project")
-
-      @quota_data =
-        services.resource_management.quota_data(
-          current_user.domain_id || current_user.project_domain_id,
-          current_user.project_id,
-          [
-            { service_type: :network, resource_name: :security_groups },
-            { service_type: :network, resource_name: :security_group_rules },
-          ],
-        )
     end
 
     def ports

--- a/plugins/networking/spec/controllers/floating_ips_controller_spec.rb
+++ b/plugins/networking/spec/controllers/floating_ips_controller_spec.rb
@@ -33,10 +33,6 @@ describe Networking::FloatingIpsController, type: :controller do
     allow_any_instance_of(ServiceLayer::NetworkingService).to receive(
       :elektron,
     ).and_return(double("elektron", service: @networking_service))
-
-    allow_any_instance_of(ServiceLayer::ResourceManagementService).to receive(
-      :quota_data,
-    ).and_return([])
   end
 
   describe "GET 'index'" do

--- a/plugins/networking/spec/controllers/networks/subnets_controller_spec.rb
+++ b/plugins/networking/spec/controllers/networks/subnets_controller_spec.rb
@@ -30,10 +30,6 @@ describe Networking::Networks::SubnetsController, type: :controller do
     allow_any_instance_of(ServiceLayer::NetworkingService).to receive(
       :elektron,
     ).and_return(double("elektron", service: double("network").as_null_object))
-
-    allow_any_instance_of(ServiceLayer::ResourceManagementService).to receive(
-      :quota_data,
-    ).and_return([])
   end
 
   describe "GET 'index'" do

--- a/plugins/networking/spec/controllers/networks_controller_spec.rb
+++ b/plugins/networking/spec/controllers/networks_controller_spec.rb
@@ -29,10 +29,6 @@ describe Networking::Networks::PrivateController, type: :controller do
     allow_any_instance_of(ServiceLayer::NetworkingService).to receive(
       :networks,
     ).and_return []
-
-    allow_any_instance_of(ServiceLayer::ResourceManagementService).to receive(
-      :quota_data,
-    ).and_return([])
   end
 
   describe "GET 'index'" do


### PR DESCRIPTION
These were partially already broken because Juno plugins do not see @quota_data, or they are utterly superfluous because there is no action the user can take to mitigate low quota anyway.