### PR TITLE
Fix code scanning alert no. 11: Incomplete string escaping or encoding

### DIFF
--- a/app/javascript/core/stateful_links.js
+++ b/app/javascript/core/stateful_links.js
@@ -14,7 +14,7 @@ const supportHistory = window.history.pushState && true
 
 // This method returns a parameter value for a given parameter name.
 const getParameterByName = function (url, name) {
-  name = name.replace(/[[]/, "\\[").replace(/[\]]/, "\\]")
+  name = name.replace(/\[/g, "\\[").replace(/\]/g, "\\]")
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`)
   const results = regex.exec(url)
 


### PR DESCRIPTION
Fixes [https://github.com/sapcc/elektra/security/code-scanning/11](https://github.com/sapcc/elektra/security/code-scanning/11)

To fix the problem, we need to ensure that all occurrences of the characters `[` and `]` in the `name` parameter are escaped. This can be achieved by using a regular expression with the global flag (`g`) in the `replace` method. This will ensure that every instance of the specified characters is replaced, not just the first one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
