### PR TITLE
feat(bedrock): check if plugin webconsole is available

### DIFF
--- a/app/views/application/_breadcrumb.html.haml
+++ b/app/views/application/_breadcrumb.html.haml
@@ -23,7 +23,7 @@
           = current_user && render_navigation(expand_all: true, renderer: :fancy_list, context: navigation_context(@scoped_domain_name, @scoped_project_name))
 
     .special-crumb
-      - if services.available?(:webconsole) && current_user && current_user.is_allowed?('webconsole:application_get') && @scoped_project_fid && plugin_name!='webconsole'
+      - if services.available?(:webconsole) &&  plugin_available?(:webconsole) && current_user && current_user.is_allowed?('webconsole:application_get') && @scoped_project_fid && plugin_name!='webconsole'
         = link_to 'javascript:void(0)', class: 'solo-icon-link', data: {trigger: 'webconsole:open'} do
           %span.fa-stack
             %i.fa.fa-square.fa-stack-2x


### PR DESCRIPTION
# Summary

This PR introduces a check for the WebConsole icon in the Topbar, allowing us to disable it in the context of Bedrock. Corresponding changes need to be made in `secrets -> values` by adding `webconsole` to the disabled plugins list.

# Changes Made

- Added a `plugin_available?` check to `_breadcrumb.html.haml` to control the visibility of the WebConsole icon.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1425 1425

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
