### PR TITLE
fix(instance): fix for hard reset

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -78,11 +78,15 @@ module Compute
     def console
       @instance = services.compute.find_server(params[:id])
       hypervisor = @instance.attributes["OS-EXT-SRV-ATTR:host"] || ""
-      if hypervisor.to_s.include?("nova-compute-ironic")
-        @console =
-          services.compute.remote_console(params[:id], "serial", "shellinabox")
-      else
-        @console = services.compute.remote_console(params[:id])
+      begin
+        if hypervisor.to_s.include?("nova-compute-ironic")
+          @console = services.compute.remote_console(params[:id], "serial", "shellinabox")
+        else
+          @console = services.compute.remote_console(params[:id])
+        end
+      rescue StandardError => e
+        @console_error = "Failed to get remote console: #{e.message}"
+        @console = nil
       end
       respond_to do |format|
         format.html { render action: :console, layout: "compute/console" }

--- a/plugins/compute/app/views/compute/instances/_item_actions.html.haml
+++ b/plugins/compute/app/views/compute/instances/_item_actions.html.haml
@@ -48,6 +48,7 @@
             %li
               = link_to 'Revert Resize', plugin('compute').revert_resize_instance_path(id: instance.id, action_from_show: show_view), method: :put, data: {loading_status: true}, remote: true
           - if instance.power_state==Compute::Server::RUNNING
+            - hypervisor = instance.attributes['OS-EXT-SRV-ATTR:host'] || ''
             %li.divider
             %li
               = link_to 'Stop', plugin('compute').stop_instance_path(id: instance.id, action_from_show: show_view), method: :put, data: { confirm: 'Are you sure you want to stop this instance?', ok: "Yes, stop it", confirmed: :loading_status}, remote: true
@@ -57,6 +58,9 @@
               = link_to 'Pause', plugin('compute').pause_instance_path(id: instance.id, action_from_show: show_view), method: :put, data: { confirm: 'Are you sure you want to pause this instance?', ok: "Yes, stop it", confirmed: :loading_status }, remote: true
             %li
               = link_to 'Suspend', plugin('compute').suspend_instance_path(id: instance.id, action_from_show: show_view), method: :put, data: { confirm: 'Are you sure you want to suspend this instance?', ok: "Yes, stop it", confirmed: :loading_status}, remote: true
+            - if !hypervisor.to_s.include?('nova-compute-ironic') && current_user.is_allowed?("compute:instance_hard_reset",{target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
+              %li
+                = link_to 'Hard Reset', confirm_hard_reset_instance_path(id: instance.id), data: {modal:true}
         - if current_user.is_allowed?("compute:instance_edit_securitygroups", {target: { project: @active_project, scoped_domain_name: @scoped_domain_name}})
           %li.divider
           %li
@@ -78,3 +82,4 @@
           - if current_user.is_allowed?("compute:instance_unlock")
             %li
               = link_to 'Unlock', plugin('compute').unlock_instance_path(id: instance.id, action_from_show: show_view), method: :put, data: { confirm: 'Are you sure you want to unlock this instance?', ok: "Yes, unlock it", confirmed: :loading_status }, remote: true
+

--- a/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
+++ b/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
@@ -17,7 +17,7 @@
     ?
     %br
     %br
-    Note: after the hardreset is triggered the web console will stop to work. Please wait a few seconds and reload the web console 🚀.
+    Note: after the hardreset is triggered the web console will stop to work if you have it opened. Please wait a short while and reload the web console 🚀.
   .row
     .col-md-6
       %fieldset

--- a/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
+++ b/plugins/compute/app/views/compute/instances/confirm_hard_reset.html.haml
@@ -17,7 +17,7 @@
     ?
     %br
     %br
-    Note: after the hardreset is triggered the web console will stop to work. It will reload automaticly after the countdown ends.
+    Note: after the hardreset is triggered the web console will stop to work. Please wait a few seconds and reload the web console 🚀.
   .row
     .col-md-6
       %fieldset

--- a/plugins/compute/app/views/compute/instances/console.html.haml
+++ b/plugins/compute/app/views/compute/instances/console.html.haml
@@ -6,7 +6,14 @@
   .modal-body.console
     %iframe{src: @console.url, width: '100%', height: '650px'}
 - else
-  %iframe{src: @console.url, width: '100%', height: '850px'}
+  - if @console_error
+    .alert.alert-error
+      #{@console_error}
+  - elsif @console.nil?
+    .alert.alert-warning
+      The console is not available 🙄
+  - else
+    %iframe{src: @console.url, width: '100%', height: '850px'}
 
 - if modal?
   .modal-footer

--- a/plugins/compute/app/views/compute/instances/index.html.haml
+++ b/plugins/compute/app/views/compute/instances/index.html.haml
@@ -1,6 +1,5 @@
 = render "intro"
 
-
 %form
   .toolbar.toolbar-controlcenter
     / / seach form

--- a/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
+++ b/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
@@ -8,4 +8,4 @@ $.post("<%=plugin('compute').hard_reset_instance_path({id:@instance.id})%>");
 Dashboard.hideModal();
 
 $('#console').html("<div class='countdown'/>");
-$('.countdown').html('Hard Reset was triggered 🚀<br>Please wait a few secconds and reload the Web Console');	
+$('.countdown').html('Hard Reset was triggered 🚀<br>Please wait a short while and reload the web console if you had it opened');

--- a/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
+++ b/plugins/compute/app/views/compute/instances/pre_hard_reset.js.erb
@@ -7,17 +7,5 @@ $.post("<%=plugin('compute').hard_reset_instance_path({id:@instance.id})%>");
 //close the create request window
 Dashboard.hideModal();
 
-var cnt = 15;
-// show countdown for reload
 $('#console').html("<div class='countdown'/>");
-$('.countdown').html('Hard Reset in process<br>Web Console will reload in '+cnt+'s');
-var x = setInterval(function() {
-  cnt--;
-  if (cnt == 0) {
-    clearInterval(x);
-    $('.countdown').html('reloading Web Console');
-    window.location.replace("<%=plugin('compute').console_instance_path(id: @instance.id)%>");
-  } else {
-    $('.countdown').html('Hard Reset in process<br>Web Console will reload in '+cnt+'s');
-  }
-}, 1000);
+$('.countdown').html('Hard Reset was triggered 🚀<br>Please wait a few secconds and reload the Web Console');	


### PR DESCRIPTION
# Summary

* the web console will load in any case and will show the error message from the backend if the url for the web console cannot be retrieved 
* moved also hard reset button to the object actions

![image](https://github.com/user-attachments/assets/f0093770-07b5-4952-af89-8ae7d7dfd29c)
![image](https://github.com/user-attachments/assets/390a26a7-39a1-4f4a-ac56-12a8a15b3a25)

# Related Issues

* #1423  cannot hard reset the server from elektra if web console is not loading

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
