### PR TITLE
chore(env): adjust dot env

### DIFF
--- a/dotenv.proxy.template
+++ b/dotenv.proxy.template
@@ -77,13 +77,6 @@ ACTIVE_RECORD_QUIET=true
 # these domains (list is comma separated) cannot inherit their masterdata to projects
 DOMAIN_MASTERDATA_INHERITANCE_BLACKLIST=monsoon3
 
-# used for cypress e2e tests
-TEST_DOMAIN="cc3test"
-TEST_MEMBER_USER="###TEST_USER###_TM"
-TEST_MEMBER_PASSWORD="*vault(path: shared/cc3test/ldap-user/###TEST_USER###_TM, field: password)"
-TEST_ADMIN_USER="###TEST_USER###_TA"
-TEST_ADMIN_PASSWORD="*vault(path: shared/cc3test/ldap-user/###TEST_USER###_TA, field: password)"
-
 # load elektra extensions, see also gemfile
 ELEKTRA_EXTENSION=true
 

--- a/dotenv.template
+++ b/dotenv.template
@@ -76,13 +76,6 @@ ACTIVE_RECORD_QUIET=true
 # these domains (list is comma separated) cannot inherit their masterdata to projects
 DOMAIN_MASTERDATA_INHERITANCE_BLACKLIST=monsoon3
 
-# used for cypress e2e tests
-TEST_DOMAIN="cc3test"
-TEST_MEMBER_USER="###TEST_USER###_TM"
-TEST_MEMBER_PASSWORD="*vault(path: shared/cc3test/ldap-user/###TEST_USER###_TM, field: password)"
-TEST_ADMIN_USER="###TEST_USER###_TA"
-TEST_ADMIN_PASSWORD="*vault(path: shared/cc3test/ldap-user/###TEST_USER###_TA, field: password)"
-
 # load elektra extensions, see also gemfile
 ELEKTRA_EXTENSION=true
 


### PR DESCRIPTION
…he test user anymore

# Summary

adjust dot env because we cannot access the secrets for the test user anymore

# Related Issues

* render_dot_env is not working

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
