### PR TITLE
Add clear resize error action to admin UI

### DIFF
--- a/plugins/tools/app/javascript/widgets/castellum/actions/castellum.js
+++ b/plugins/tools/app/javascript/widgets/castellum/actions/castellum.js
@@ -41,8 +41,31 @@ const fetchErrorsIfNeeded = (errorType) => (dispatch, getState) => {
   return dispatch(fetchErrors(errorType))
 }
 
+const refetchErrorsOnDemand = () => (dispatch) => {
+  for (const errorType of constants.CASTELLUM_ERROR_TYPES) {
+    dispatch(fetchErrors(errorType))
+  }
+}
+
 export const fetchAllErrorsAsNeeded = () => (dispatch) => {
   for (const errorType of constants.CASTELLUM_ERROR_TYPES) {
     dispatch(fetchErrorsIfNeeded(errorType))
   }
+}
+
+const clearError = (error) => (dispatch) => {
+  const { project_id, asset_type, asset_id } = error
+  return new Promise((handleSuccess, handleErrors) =>
+    ajaxHelper
+      .post(`/v1/projects/${project_id}/assets/${asset_type}/${asset_id}/error-resolved`)
+      .then(() => {
+        handleSuccess()
+        dispatch(refetchErrorsOnDemand())
+      })
+      .catch((error) => handleErrors(console.log(errorMessage(error))))
+  )
+}
+
+export const clearErrorIfNeeded = (error) => (dispatch) => {
+  dispatch(clearError(error))
 }

--- a/plugins/tools/app/javascript/widgets/castellum/components/error_list.jsx
+++ b/plugins/tools/app/javascript/widgets/castellum/components/error_list.jsx
@@ -131,7 +131,7 @@ export default class Loader extends React.Component {
         pageSize={6}
       >
         {data.map((error, idx) => (
-          <ErrorRow key={`error${idx}`} error={error} action={{label: "Clear", fn: this.onAction}}/>
+          <ErrorRow key={`error${idx}`} error={error} action={{label: "Mark as resolved", fn: this.onAction}}/>
         ))}
       </DataTable>
     )

--- a/plugins/tools/app/javascript/widgets/castellum/components/error_list.jsx
+++ b/plugins/tools/app/javascript/widgets/castellum/components/error_list.jsx
@@ -23,7 +23,7 @@ const sortKeyForTimestamp = (props) => {
 const columnSets = {
   "resource-scrape-errors": ["project", "asset_type", "timestamp"],
   "asset-scrape-errors": ["project", "asset", "timestamp"],
-  "asset-resize-errors": ["project", "asset", "size", "timestamp"],
+  "asset-resize-errors": ["project", "asset", "size", "timestamp", "clear"],
 }
 const columnDefs = [
   {
@@ -56,14 +56,27 @@ const columnDefs = [
     sortStrategy: "numeric",
     sortKey: sortKeyForTimestamp,
   },
+  {
+    key: "clear",
+    label: "Action",
+  },
 ]
 
 export default class Loader extends React.Component {
+  constructor(props) {
+    super(props)
+    this.onAction = this.onAction.bind(this)
+  }
+
   componentDidMount() {
     this.props.fetchAllErrorsAsNeeded()
   }
   componentDidUpdate() {
     this.props.fetchAllErrorsAsNeeded()
+  }
+
+  onAction (error) {
+    this.props.clearErrorIfNeeded(error)
   }
 
   render() {
@@ -118,7 +131,7 @@ export default class Loader extends React.Component {
         pageSize={6}
       >
         {data.map((error, idx) => (
-          <ErrorRow key={`error${idx}`} error={error} />
+          <ErrorRow key={`error${idx}`} error={error} action={{label: "Clear", fn: this.onAction}}/>
         ))}
       </DataTable>
     )

--- a/plugins/tools/app/javascript/widgets/castellum/components/error_row.jsx
+++ b/plugins/tools/app/javascript/widgets/castellum/components/error_row.jsx
@@ -1,7 +1,9 @@
+import Button from "react-bootstrap/lib/Button"
 import { PrettyDate } from "lib/components/pretty_date"
 import React from "react"
 
 const ErrorRow = (props) => {
+  const { label="None", fn=() => {} } = props.action ||{} 
   const {
     project_id: projectID,
     asset_type: assetType,
@@ -40,6 +42,9 @@ const ErrorRow = (props) => {
         <td className={hasSizeColumn ? "col-md-2" : "col-md-3"}>
           {result.at ? <PrettyDate date={result.at} /> : "None"}
         </td>
+        {hasSizeColumn && <td className="col-md-1">
+          <Button onClick={() => {fn(props.error)}}>{label}</Button>
+        </td>}
       </tr>
       <tr className="explains-previous-line">
         <td colSpan={hasSizeColumn ? 4 : 3} className="text-danger">

--- a/plugins/tools/app/javascript/widgets/castellum/containers/error_list.js
+++ b/plugins/tools/app/javascript/widgets/castellum/containers/error_list.js
@@ -1,6 +1,6 @@
 import { connect } from  'react-redux';
 import ErrorList from '../components/error_list';
-import { fetchAllErrorsAsNeeded } from '../actions/castellum';
+import { clearErrorIfNeeded, fetchAllErrorsAsNeeded } from '../actions/castellum';
 
 export default connect(
   (state, props) => {
@@ -13,5 +13,6 @@ export default connect(
   },
   dispatch => ({
     fetchAllErrorsAsNeeded: (...args) => dispatch(fetchAllErrorsAsNeeded(...args)),
+    clearErrorIfNeeded: (error) => dispatch(clearErrorIfNeeded(error))
   }),
 )(ErrorList);


### PR DESCRIPTION
# Summary

Errors in Castellum that are from the type "resize" do not get immediately resolved when the error disappears. It only disappears after another resize attempt on the resource occurs. For this case a new API endpoint was introduced that clears an error from the database early. The follwing changes are present:

- Add new Action column to the resize error table
- Content is a "Clear" button that aims to remove the error from the error list.
- Implement the API endpoint and the caller function
- Refetch existing errors after calling the "Clear" functionality.

# Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/6f092b57-ab98-4862-864e-bb1d793c5798)

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
