### PR TITLE
fix(castellum): Add initial value to threshold crossing

### DIFF
--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/edit.jsx
@@ -201,6 +201,7 @@ export default class CastellumConfigurationEditModal extends React.Component {
       size_minimum: (cfg.size_constraints || {}).minimum || "",
       size_maximum: (cfg.size_constraints || {}).maximum || "",
       free_minimum: (cfg.size_constraints || {}).minimum_free || "",
+      minimum_free_is_critical: (cfg.size_constraints || {}).minimum_free_is_critical || false,
     }
   }
 

--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -115,6 +115,11 @@ export default class CastellumConfigurationView extends React.Component {
                 free space.
               </li>
             )}
+            {config.size_constraints.minimum_free_is_critical && (
+              <li>
+                ...resize without delay.
+              </li>
+            )}
           </ul>
         )}
         <p>


### PR DESCRIPTION
# Summary

The implementation to set a critical threshold value for autoscaling works, but has the flaw that it does not represent the value as a checked box as an initial value on application start. This PR fixes that.

# Screenshots (if applicable)

An example. The existing configuration has threshold crossing active. Before the fix, the checkbox would not have been checked initially.
<img width="838" alt="image" src="https://github.com/user-attachments/assets/ab9cb10d-d236-4f01-81e6-0964d94efb87">

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
