### PR TITLE
chore(resources): do not hide nav item

### DIFF
--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -422,7 +422,7 @@ SimpleNavigation::Configuration.run do |navigation|
                  },
                  if:
                    lambda {
-                     (services.available?(:resources) && plugin_available?(:resources) && current_user.is_allowed?('resources:project:edit')) ||
+                     (services.available?(:resources) && plugin_available?(:resources)) ||
                        (services.available?(:masterdata_cockpit) && plugin_available?(:masterdata_cockpit)) &&
                          plugin_available?(:resources) ||
                        plugin_available?(:metrics) ||
@@ -434,7 +434,7 @@ SimpleNavigation::Configuration.run do |navigation|
                           -> { plugin('resources').v2_project_path },
                           if: lambda {
                             # current_region.start_with?("qa-") &&
-                            plugin_available?(:resources) && current_user.is_allowed?('resources:project:edit')
+                            plugin_available?(:resources)
                           },
                           highlights_on:
                             proc { params[:controller][%r{resources/v2}] }


### PR DESCRIPTION
# Summary

This PR removes the permission checks for the Limes UI in the project navigation. Users who lack the resources:project:edit permission cannot edit resources but can still view them. Therefore, we are removing this check to ensure the UI is displayed consistently. The UI itself will handle permission verification where necessary.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
