### PR TITLE
fix(ci): fix init-db script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,7 @@ RUN apk --no-cache add git curl nodejs yarn shared-mime-info yaml-dev
 # Install gems with native extensions before running bundle install
 # This avoids recompiling them everytime the Gemfile.lock changes.
 # The versions need to be kept in sync with the Gemfile.lock
-RUN apk --no-cache add build-base postgresql16-dev ruby-sassc --virtual .builddeps \
+RUN apk --no-cache add build-base postgresql16-dev ruby-sassc libsass-dev --virtual .builddeps \
     && gem install --no-document \
     bundler:2.3.20 \
     byebug:11.1.3 \
@@ -90,7 +90,6 @@ ADD script/organize_plugins_gemspecs script/
 RUN script/organize_plugins_gemspecs
 
 # install gems, copy app and run rake tasks
-RUN apk --no-cache add build-base
 RUN bundle config set --local without 'development integration_tests'
 RUN bundle install --jobs=$(nproc)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,12 +45,12 @@ FROM base AS builder
 
 RUN echo "Rebuild image 2"
 # Note: we need to install git here because bundle needs git in the next step
-RUN apk --no-cache add git curl nodejs yarn shared-mime-info yaml-dev
+RUN apk --no-cache add git curl nodejs yarn shared-mime-info 
 
 # Install gems with native extensions before running bundle install
 # This avoids recompiling them everytime the Gemfile.lock changes.
 # The versions need to be kept in sync with the Gemfile.lock
-RUN apk --no-cache add build-base postgresql16-dev ruby-sassc libsass-dev --virtual .builddeps \
+RUN apk --no-cache add build-base postgresql16-dev ruby-sassc libsass-dev yaml-dev --virtual .builddeps \
     && gem install --no-document \
     bundler:2.3.20 \
     byebug:11.1.3 \


### PR DESCRIPTION
# Summary

this will fix the error for init-db:

```
rake aborted!
LoadError: Could not open library '/usr/local/bundle/gems/sassc-2.4.0/ext/libsass.so': Error loading shared library /usr/local/bundle/gems/sassc-2.4.0/ext/libsass.so: No such file or directory
```

there was an update for `ruby:3.2.6-alpine3.20` that needs to add some dev libraries that where present in the older version

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
