### PR TITLE
fix(core): defer avatar img loading to unblock auth_projects fetch

### DIFF
--- a/app/assets/stylesheets/_monsoon_theme.scss
+++ b/app/assets/stylesheets/_monsoon_theme.scss
@@ -1058,12 +1058,9 @@ section {
 .avatar {
   background: inline_svg("avatar_default") no-repeat;
   background-size: contain;
-  height: 24px;
-  width: 24px;
-
   margin-right: 3px;
 
-  img {
+  &, img {
     border-radius: 3px;
     height: 24px;
     width: 24px;
@@ -1071,9 +1068,7 @@ section {
 }
 
 .avatar_profile {
-  height: 140px;
-  width: 140px;
-  img {
+  &, img {
     height: 140px;
     width: 140px;
   }

--- a/app/javascript/core/avatar_loader.js
+++ b/app/javascript/core/avatar_loader.js
@@ -1,30 +1,42 @@
 window.loadAvatar = function ({ avatarUrl, elementId }) {
-  document.addEventListener("DOMContentLoaded", function () {
-    const loadImage = new Promise((resolve, reject) => {
-      var img = new Image()
-      // handle the case where the image does not exist
-      // try to load the image
-      img.onload = function () {
-        // if the image exists, set the src attribute of the image element
-        // console.info(`Loading avatar image from ${avatarUrl} into element with id ${elementId}.`)
-        document.getElementById(elementId).insertAdjacentHTML("beforeend", `<img src="${avatarUrl}" />`)
-        resolve()
-      }
-      img.onerror = function () {
-        // if the image does not exist, use the default image
-        console.warn(`Avatar image ${avatarUrl} does not exist, using default image.`)
-        reject()
-      }
-      // set the src attribute to the image url
-      img.src = avatarUrl
-    })
+  const executeLoad = () => {
+    // Defer image loading until browser is idle, otherwise it may block other javascript execution
+    // In our case, if the image loading ran into a timeout, the auth_projects fetch would be blocked until the timeout was reached
+    requestIdleCallback(() => { 
+      const img = new Image();
+      let isHandled = false;
 
-    loadImage
-      .then(() => {
-        console.info(`Successfully loaded avatar from ${avatarUrl}.`)
-      })
-      .catch(() => {
-        console.warn(`Failed to load avatar image.`)
-      })
-  })
-}
+      const handleFailure = () => {
+        if (!isHandled) {
+          isHandled = true;
+          console.warn(`Avatar image ${avatarUrl} did not load in time, using default image.`);
+        }
+      };
+
+      img.onload = function () {
+        if (!isHandled) {
+          isHandled = true;
+          const container = document.getElementById(elementId);
+          if (container) {
+            container.appendChild(img); 
+          }
+          console.info(`Successfully loaded avatar from ${avatarUrl}.`);
+        }
+      };
+
+      img.onerror = handleFailure;
+
+      // Fail fast if image doesn't load in 5 seconds
+      setTimeout(handleFailure, 5000);
+
+      img.src = avatarUrl; // Start loading the image
+    }, { timeout: 5000 }); // Wait up to 5 seconds before forcing execution
+  };
+
+  // Ensure DOM is ready before running loadAvatar
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", executeLoad);
+  } else {
+    executeLoad();
+  }
+};


### PR DESCRIPTION
## Summary

This PR refactors the `loadAvatar` function to ensure it is **truly non-blocking** and does not interfere with other asynchronous operations, such as fetch requests.

Even though the original implementation wrapped image loading in a Promise to try to unblock other requests, this still unintentionally deferred other API calls due to browser network prioritization (the browser tried to load images first). In our case this led to the `auth_projects` call being deferred until after the image load was completed or failed.

This updated implementation leverages `requestIdleCallback()` to defer image loading until the browser is idle, ensuring that fetch requests are not delayed.

## Changes Made

### 1. **Removed Unnecessary Promise Wrapping**
   - The original implementation used a Promise to handle image loading.
   - Since image loading is already **event-driven** (`onload` / `onerror`), wrapping it in a Promise was unnecessary.
   - The new implementation **removes the Promise**, reducing overhead.

### 2. **Eliminated `insertAdjacentHTML()` in Favor of Direct DOM Manipulation**
   - Previously, a new `<img>` element was created using `insertAdjacentHTML()`, which caused **duplicate element creation**.
   - The new approach **inserts the preloaded image element directly** using `appendChild()`

### 3. **Deferred Image Loading Using `requestIdleCallback()`**
   - In the original version, calling `img.src = avatarUrl` immediately triggered an image request, which could **block or delay fetch() requests** (particularly noticeable for `auth_projects`).
   - The updated version **uses `requestIdleCallback()`** to start loading images **only when the browser is idle**.
   - This ensures that **critical fetch requests complete first**

### 4. **Added a Timeout to Ensure Images Load Within a Reasonable Time**
   - If the browser is never idle (e.g., due to user interactions), `requestIdleCallback()` might delay execution indefinitely.
   - A **`timeout: 5000` (5 seconds)** ensures that the image still loads **even if the browser is under constant load**.

### 5. **Preserved `DOMContentLoaded` Handling**
   - If `loadAvatar` is called before the DOM is ready, it waits for `DOMContentLoaded` before executing.
   - If the DOM is already loaded, it runs immediately.

### 6. **CSS improvements**
  - Unrelated to the above fix, improved avatar css by reducing repetition of width/height setting.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
