### PR TITLE
chore(core): use specific excon version in dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,9 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console'
+  # this version is the last version that works with mitmproxy
+  # if you use the versions above you will get "Excon::Error::ProxyConnectionError" if you use http_proxy env with Excon
+  gem 'excon', '0.112.0' 
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,7 +348,7 @@ GEM
       zeitwerk (~> 2.6)
     ed25519 (1.3.0)
     erubi (1.12.0)
-    excon (1.2.3)
+    excon (0.112.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -630,6 +630,7 @@ DEPENDENCIES
   ed25519 (>= 1.2, < 2.0)
   elektron!
   email_service!
+  excon (= 0.112.0)
   factory_bot_rails
   faraday-httpclient (~> 2.0)
   filewatcher


### PR DESCRIPTION
# Summary

* this will use for development mode a version of excon that is working with local proxy to trace and debug api calls

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
