### PR TITLE
chore(build): removes not needed references

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,8 +31,6 @@ ENV MONSOON_NEW_PROJECT_DL=$MONSOON_NEW_PROJECT_DL
 # container.
 # https://github.com/rails/rails/issues/32947
 ENV MONSOON_RAILS_SECRET_TOKEN=dummy_monsoon_rails_build_secret_token_for_assets_precompiling_change_it_in_production
-ARG MONSOON_RAILS_SECRET_TOKEN
-ENV MONSOON_RAILS_SECRET_TOKEN=$MONSOON_RAILS_SECRET_TOKEN
 
 WORKDIR $APP_PATH
 


### PR DESCRIPTION
# Summary

Removes `build-time` variable that can be passed via `docker build --build-arg MONSOON_RAILS_SECRET_TOKEN=actual_value`. The value is being override when deploying [here](https://github.com/sapcc/helm-charts/blob/master/openstack/elektra/templates/_env.tpl#L57).

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Removes unnecessary `build-time` variable

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
