### PR TITLE
feat(access-profile): check for disabled plugin

### DIFF
--- a/plugins/identity/app/views/identity/projects/_additional_infos.haml
+++ b/plugins/identity/app/views/identity/projects/_additional_infos.haml
@@ -19,7 +19,7 @@
           %td
             = link_to plugin('identity').edit_project_path({load_project_root: true}), data: {modal: true, toggle: "tooltip", placement: "left"} do
               Edit
-      - if current_user.is_allowed?("access_profile:tag_list", {target: {project: @active_project}})
+      - if current_user.is_allowed?("access_profile:tag_list", {target: {project: @active_project}}) && plugin_available?(:access_profile)
         %tr
           %th.snug-nowrap
             Access Profiles:


### PR DESCRIPTION
# Summary

* this will hide the `edit access-profile` link in the project description if the `access-profile` plugin is dsiabled

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
