### PR TITLE
chore(key-manager): make new keymanager ui default

### DIFF
--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -221,7 +221,7 @@ SimpleNavigation::Configuration.run do |navigation|
                  },
                  if:
                    lambda {
-                     plugin_available?(:key_manager) or
+                     plugin_available?(:keymanagerng) or
                        (plugin_available?(:identity) && services.available?(:identity) and
                          current_user &&
                            (
@@ -266,16 +266,15 @@ SimpleNavigation::Configuration.run do |navigation|
                                    ) && plugin_available?(:identity)
                                  },
                                  highlights_on: %r{identity/projects/groups/?.*}
-      access_management_nav.item :key_manager,
+      access_management_nav.item :keymanagerng,
                                  'Key Manager',
-                                 -> { plugin('key_manager').secrets_path },
+                                 -> { plugin('keymanagerng').root_path },
                                  if: lambda {
-                                   services.available?(:key_manager) &&
-                                     plugin_available?(:key_manager)
+                                   plugin_available?(:keymanagerng)
                                  },
                                  highlights_on:
                                    proc {
-                                     params[:controller][%r{key_manager/.*}]
+                                     params[:controller][%r{keymanagerng/.*}]
                                    }
     end
 
@@ -304,7 +303,9 @@ SimpleNavigation::Configuration.run do |navigation|
       networking_nav.item :backup_networks,
                           'Backup Networks',
                           -> { plugin('networking').backup_networks_path },
-                          if: -> { plugin_available?(:networking) && !@domain_config.feature_hidden?('networking_backup') },
+                          if: lambda {
+                            plugin_available?(:networking) && !@domain_config.feature_hidden?('networking_backup')
+                          },
                           highlights_on: %r{networking/(backup_networks)/?.*}
       networking_nav.item :ports,
                           'Fixed IPs / Ports',

--- a/plugins/keymanagerng/app/views/keymanagerng/application/show.html.haml
+++ b/plugins/keymanagerng/app/views/keymanagerng/application/show.html.haml
@@ -1,11 +1,4 @@
 = content_for :main_toolbar do
   Key Manager
 
-%script{"data-importmap-only" => "true", :src => "https://assets.juno.global.cloud.sap/apps/widget-loader@latest/build/app.js"}
-
-.bs-callout.bs-callout-info.bs-callout-emphasize
-  %p
-    This is the new version of Key Manager. If you prefer to use the previous version, click 
-    =link_to "here", plugin('key_manager').secrets_path, data: { target: 'nav-to-old-key-manager' }
-
 = javascript_include_tag "keymanagerng_app_widget", data: { url: plugin("keymanagerng").root_path }


### PR DESCRIPTION
# Summary

This PR updates the application to make the new Key Manager UI the default. The old UI cannot be fully removed yet due to shared functionality in the service layer.

# Changes Made

- Updated the Main Navigation to link to the new Key Manager UI.
- Removed the dependency on the assets server.

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1461

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
