### PR TITLE
chore(networking): remove the checks for create router

### DIFF
--- a/plugins/networking/app/controllers/networking/routers_controller.rb
+++ b/plugins/networking/app/controllers/networking/routers_controller.rb
@@ -143,6 +143,9 @@ module Networking
     end
 
     def create
+      if params["router"]["external_gateway_info"]["network_id"].blank?
+        params["router"].delete("external_gateway_info")
+      end
       # get selected subnets and remove them from params
       @selected_internal_subnets =
         (params[:router].delete(:internal_subnets) || []).reject(&:empty?)

--- a/plugins/networking/app/javascript/plugin/router.js
+++ b/plugins/networking/app/javascript/plugin/router.js
@@ -9,9 +9,7 @@ const subnets = {}
 const $loader = $('<span class="spinner"></span>')
 
 const showSubnets = function (subnets) {
-  const $select = $(
-    "#router_external_gateway_info_external_fixed_ips_subnet_id"
-  )
+  const $select = $("#router_external_gateway_info_external_fixed_ips_subnet_id")
   const selected = $select.data("selected")
   $select.empty()
 
@@ -26,24 +24,11 @@ const showSubnets = function (subnets) {
 
   for (var subnet of sortedSubnets) {
     var available_ips = subnet.total_ips - subnet.used_ips
-    var isSelectedInfo =
-      $.inArray(subnet.subnet_id, selected) > -1 ? "selected" : ""
+    var isSelectedInfo = $.inArray(subnet.subnet_id, selected) > -1 ? "selected" : ""
     var isDisabledInfo = available_ips <= 0 ? "disabled" : ""
 
     $select.append(
       `<option ${isSelectedInfo} ${isDisabledInfo} value="${subnet.subnet_id}">${subnet.subnet_name} (${subnet.cidr}, available IPs: ${available_ips})</option>`
-    )
-  }
-
-  if ($select.val().trim().length === 0) {
-    $('form[data-router-form=true] button[type="submit"]').prop(
-      "disabled",
-      true
-    )
-  } else {
-    $('form[data-router-form=true] button[type="submit"]').prop(
-      "disabled",
-      false
     )
   }
 
@@ -53,20 +38,12 @@ const showSubnets = function (subnets) {
 const loadSubnets = function (networkId) {
   if (!networkId || networkId.trim().length === 0) {
     $("fieldset#subnets .form-group").hide()
-    $('form[data-router-form=true] button[type="submit"]').prop(
-      "disabled",
-      false
-    )
     return
   }
 
   if (subnets[networkId]) {
     return showSubnets(subnets[networkId])
   } else {
-    $('form[data-router-form=true] button[type="submit"]').prop(
-      "disabled",
-      true
-    )
     $("fieldset#subnets .form-group").hide()
     $("fieldset#subnets").append($loader)
     return $.ajax({
@@ -84,18 +61,10 @@ const loadSubnets = function (networkId) {
 
 const init = function () {
   if (
-    $("#router_external_gateway_info_external_fixed_ips_subnet_id").length ===
-      0 ||
-    (
-      $("#router_external_gateway_info_external_fixed_ips_subnet_id")[0]
-        .value || ""
-    ).trim().length === 0
+    $("#router_external_gateway_info_external_fixed_ips_subnet_id").length === 0 ||
+    ($("#router_external_gateway_info_external_fixed_ips_subnet_id")[0].value || "").trim().length === 0
   ) {
     $("fieldset#subnets .form-group").hide()
-    $('form[data-router-form=true] button[type="submit"]').prop(
-      "disabled",
-      true
-    )
   }
 
   $("#router_external_gateway_info_network_id").change(function () {
@@ -105,22 +74,6 @@ const init = function () {
   if ($("#router_external_gateway_info_network_id").val()) {
     loadSubnets($("#router_external_gateway_info_network_id").val())
   }
-
-  return $("#router_external_gateway_info_external_fixed_ips_subnet_id").change(
-    function () {
-      if (this.value.trim().length === 0) {
-        return $('form[data-router-form=true] button[type="submit"]').prop(
-          "disabled",
-          true
-        )
-      } else {
-        return $('form[data-router-form=true] button[type="submit"]').prop(
-          "disabled",
-          false
-        )
-      }
-    }
-  )
 }
 
 $(document).on("modal:contentUpdated", (e) => init())

--- a/plugins/networking/app/models/networking/router.rb
+++ b/plugins/networking/app/models/networking/router.rb
@@ -6,11 +6,6 @@ module Networking
     validates :name, presence: { message: "Please provide a name" }
 
     attr_accessor :internal_subnets
-    validates :internal_subnets,
-              presence: {
-                message:
-                  "Please select at least one subnet from the private network subnets",
-              }
 
     def ip_subnet_objects
       return @ip_subnet_objects if @ip_subnet_objects

--- a/plugins/networking/app/views/networking/routers/new.html.haml
+++ b/plugins/networking/app/views/networking/routers/new.html.haml
@@ -15,9 +15,10 @@
       = info.input :network_id, {label: "Floating IP Network",
         input_html:         {},
         as:                 :select,
+        include_blank:      ' ',
         collection:         @external_networks.sort{ |a,b| a.highest_asr_agents_count<=>b.highest_asr_agents_count},
         selected:           @router.external_gateway_info.fetch("network_id",nil),
-        required:           true,
+        required:           false,
         icon_hint:          "Please prefer in your choise the networks from top to bottom"}
 
       %fieldset#subnets
@@ -35,7 +36,7 @@
       collection:         @internal_subnets.sort{|a,b| a.network_name<=>b.network_name},
       selected:           @selected_internal_subnets,
       label_method:       -> s {"#{s.name} (#{s.network_name})"},
-      required:           true}
+      required:           false}
 
   %div.buttons{class: modal? ? 'modal-footer' : ''}
     - if modal?


### PR DESCRIPTION
# Summary

this PR will remove the checks for `fip network` and `subnet` in the create form for routers because these fields are optional from openstack side. The old behavior is to strict and was build in mind that the router is always used to communicate with the outside world. But routers can also be used to bind internal networks together. That was not possible with the old behavior because you must choose a FIP Network and subnet for the router. 

Now it is possible to create just the router without any subnets and add them later

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
