### PR TITLE
fix(key-manager): adds base64 payload content encoding for all relevant payload content types in new secret form

### DIFF
--- a/plugins/keymanagerng/app/controllers/keymanagerng/application_controller.rb
+++ b/plugins/keymanagerng/app/controllers/keymanagerng/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Keymanagerng
-  class ApplicationController < AjaxController
+  class ApplicationController < DashboardController
     def user_name
       # byebug
       render json:

--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/newSecretForm.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/newSecretForm.jsx
@@ -100,6 +100,9 @@ const secretTypeRelToPayloadContentType = (secretType) => {
       return []
   }
 }
+const shouldShowBase64Warning = (payloadContentType) => {
+  return [TYPE_PKCS8, TYPE_OCTET_STREAM, TYPE_PKIX_CERT].includes(payloadContentType)
+}
 
 const formValidation = (formData) => {
   let errors = {}
@@ -366,9 +369,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
               setFormData({
                 ...formData,
                 payload_content_type: value,
-                payload_content_encoding: [TYPE_PKCS8, TYPE_OCTET_STREAM, TYPE_PKIX_CERT].includes(value)
-                  ? "base64"
-                  : undefined, // Reset if not in the list
+                payload_content_encoding: shouldShowBase64Warning(value) ? "base64" : undefined, // Reset if not in the list
               })
             }}
             placeholder={formData.secret_type ? "Select..." : "Please first select a secret type"}
@@ -388,7 +389,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
               ))}
           </Select>
         </FormRow>
-        {[TYPE_PKCS8, TYPE_OCTET_STREAM, TYPE_PKIX_CERT].includes(formData.payload_content_type) && (
+        {shouldShowBase64Warning(formData.payload_content_type) && (
           <>
             <FormRow>
               <Message

--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/newSecretForm.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/newSecretForm.jsx
@@ -132,25 +132,12 @@ const SecretTypeHelpText = ({ showMore, handleShowMore }) => {
         </Stack>
       ) : (
         <>
-          <p>
-            certificate - Used for storing cryptographic certificates such as
-            X.509 certificates
-          </p>
-          <p>
-            opaque - Used for backwards compatibility with previous versions of
-            the API without typed secrets
-          </p>
+          <p>certificate - Used for storing cryptographic certificates such as X.509 certificates</p>
+          <p>opaque - Used for backwards compatibility with previous versions of the API without typed secrets</p>
           <p>passphrase - Used for storing plain text passphrases</p>
-          <p>
-            private - Used for storing the private key of an asymmetric keypair
-          </p>
-          <p>
-            public - Used for storing the public key of an asymmetric keypair
-          </p>
-          <p>
-            symmetric - Used for storing byte arrays such as keys suitable for
-            symmetric encryption
-          </p>
+          <p>private - Used for storing the private key of an asymmetric keypair</p>
+          <p>public - Used for storing the public key of an asymmetric keypair</p>
+          <p>symmetric - Used for storing byte arrays such as keys suitable for symmetric encryption</p>
           <Stack alignment="center">
             <p>Hide info about secret types</p>
             <Icon icon="chevronLeft" onClick={handleHide} />
@@ -209,9 +196,6 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
   const onSecretTypeChange = (secretType) => {
     let options = { secret_type: secretType }
 
-    if (secretType === "symmetric") {
-      options["payload_content_encoding"] = "base64"
-    }
     setPayloadContentTypeOptions(secretTypeRelToPayloadContentType(secretType))
     return setFormData({ ...formData, ...options })
   }
@@ -224,12 +208,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
     <PanelBody
       footer={
         <PanelFooter>
-          <Button
-            label="Save"
-            onClick={onConfirm}
-            variant="primary"
-            data-target="save-secret-btn"
-          />
+          <Button label="Save" onClick={onConfirm} variant="primary" data-target="save-secret-btn" />
           <Button label="Cancel" onClick={onClose} />
         </PanelFooter>
       }
@@ -267,10 +246,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
                   // Set the time to the end of the day (23:59:59)
                   selectedDateTime.setHours(23, 59, 59)
 
-                  if (
-                    isToday(selectedDate) ||
-                    isAfter(selectedDate, currentDate)
-                  ) {
+                  if (isToday(selectedDate) || isAfter(selectedDate, currentDate)) {
                     setSelectedDay(selectedDate)
                     setFormData({
                       ...formData,
@@ -283,8 +259,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
                   } else {
                     setValidationState({
                       ...validationState,
-                      expiration:
-                        "Selected date must be greater than the current date and time!",
+                      expiration: "Selected date must be greater than the current date and time!",
                     })
                     setSelectedDay(null)
                   }
@@ -295,21 +270,13 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
             {validationState?.expiration && (
               <FormRow>
                 <p className="tw-text-xs tw-text-theme-error">
-                  {validationState?.expiration
-                    ? validationState?.expiration
-                    : ""}
+                  {validationState?.expiration ? validationState?.expiration : ""}
                 </p>
               </FormRow>
             )}
             {selectedDay && (
               <FormRow>
-                <p>
-                  Selected date is:{" "}
-                  {format(
-                    new Date(selectedDay).setHours(23, 59, 59),
-                    "MMMM d, yyyy HH:mm:ss"
-                  )}
-                </p>
+                <p>Selected date is: {format(new Date(selectedDay).setHours(23, 59, 59), "MMMM d, yyyy HH:mm:ss")}</p>
               </FormRow>
             )}
             <FormRow>
@@ -364,12 +331,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
             invalid={validationState?.secret_type ? true : false}
             required
             data-target="secret-type-select"
-            helptext={
-              <SecretTypeHelpText
-                showMore={showMore}
-                handleShowMore={handleShowMore}
-              />
-            }
+            helptext={<SecretTypeHelpText showMore={showMore} handleShowMore={handleShowMore} />}
           >
             {selectTypes("all").map((item, index) => (
               <SelectOption
@@ -388,9 +350,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
             onChange={(oEvent) => {
               setFormData({ ...formData, payload: oEvent.target.value })
             }}
-            helptext={
-              validationState?.payload ? "" : "The secret’s data to be stored"
-            }
+            helptext={validationState?.payload ? "" : "The secret’s data to be stored"}
             errortext={validationState?.payload}
             invalid={validationState?.payload ? true : false}
             className="tw-h-64"
@@ -406,13 +366,12 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
               setFormData({
                 ...formData,
                 payload_content_type: value,
+                payload_content_encoding: [TYPE_PKCS8, TYPE_OCTET_STREAM, TYPE_PKIX_CERT].includes(value)
+                  ? "base64"
+                  : undefined, // Reset if not in the list
               })
             }}
-            placeholder={
-              formData.secret_type
-                ? "Select..."
-                : "Please first select a secret type"
-            }
+            placeholder={formData.secret_type ? "Select..." : "Please first select a secret type"}
             errortext={validationState?.payload_content_type}
             invalid={validationState?.payload_content_type ? true : false}
             data-target="payload-content-type-select"
@@ -421,9 +380,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
             {!!formData.secret_type &&
               payloadContentTypeOptions.map((item, index) => (
                 <SelectOption
-                  data-target={
-                    "payload-content-type-select-option-" + item.label
-                  }
+                  data-target={"payload-content-type-select-option-" + item.label}
                   key={index}
                   label={item.label}
                   value={item.value}
@@ -431,7 +388,7 @@ const NewSecretForm = ({ onSuccessfullyCloseForm, onClose }) => {
               ))}
           </Select>
         </FormRow>
-        {formData.secret_type === "symmetric" && (
+        {[TYPE_PKCS8, TYPE_OCTET_STREAM, TYPE_PKIX_CERT].includes(formData.payload_content_type) && (
           <>
             <FormRow>
               <Message

--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -95,7 +95,6 @@ const SecretDetails = () => {
     queryFn: getSecretPayload,
     enabled:
       payloadRequested || // Enable when download requested
-<<<<<<< HEAD
       (!!secretId &&
         isPayloadContentTypeTextPlain(secret?.data?.content_types?.default)), // Enable for text/plain content types when panel is shown
     onSuccess: (data) => {
@@ -104,26 +103,6 @@ const SecretDetails = () => {
       }
       if (payloadRequested) {
         //Downloading the payload content as a file
-=======
-      (![
-        "application/octet-stream",
-        "application/pkcs8",
-        "application/pkix-cert",
-      ].includes(secret?.data?.content_types?.default) &&
-        show), // Enable for specific content types when panel is shown
-    onSuccess: (data) => {
-      if (
-        ![
-          "application/octet-stream",
-          "application/pkcs8",
-          "application/pkix-cert",
-        ].includes(secret?.data?.content_types?.default)
-      ) {
-        // Handle payload types other than specific ones by returning as a string
-        setPayloadString(data)
-      } else {
-        // Handle specific payload types by downloading the content as a file
->>>>>>> 716cc4a9b ([keymanagerng] Download payload file as a row file not a json file and show the content directly in the UI if the type is text/plain)
         const fileData = JSON.stringify(data)
         const blob = new Blob([fileData], {
           type: secret?.data?.content_types?.default,
@@ -213,31 +192,11 @@ const SecretDetails = () => {
                 <DataGridHeadCell>{"Payload"}</DataGridHeadCell>
                 <DataGridCell>
                   <div>
-<<<<<<< HEAD
                     <Button
                       icon="download"
                       label="Download"
                       onClick={handleDownload} // Trigger download on button click
                     />
-=======
-                    {[
-                      "application/octet-stream",
-                      "application/pkcs8",
-                      "application/pkix-cert",
-                    ].includes(secret?.data?.content_types?.default) ? (
-                      <Button
-                        icon="download"
-                        label="Download"
-                        onClick={handleDownload} // Trigger download on button click
-                      />
-                    ) : payloadString ? (
-                      // Show payload text if content types are not for downloading and payload exists
-                      <span>{payloadString}</span>
-                    ) : (
-                      // Show no payload message when no file to download and no payload text available
-                      <span>No payload available</span>
-                    )}
->>>>>>> 716cc4a9b ([keymanagerng] Download payload file as a row file not a json file and show the content directly in the UI if the type is text/plain)
                   </div>
                 </DataGridCell>
               </DataGridRow>

--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -95,6 +95,7 @@ const SecretDetails = () => {
     queryFn: getSecretPayload,
     enabled:
       payloadRequested || // Enable when download requested
+<<<<<<< HEAD
       (!!secretId &&
         isPayloadContentTypeTextPlain(secret?.data?.content_types?.default)), // Enable for text/plain content types when panel is shown
     onSuccess: (data) => {
@@ -103,6 +104,26 @@ const SecretDetails = () => {
       }
       if (payloadRequested) {
         //Downloading the payload content as a file
+=======
+      (![
+        "application/octet-stream",
+        "application/pkcs8",
+        "application/pkix-cert",
+      ].includes(secret?.data?.content_types?.default) &&
+        show), // Enable for specific content types when panel is shown
+    onSuccess: (data) => {
+      if (
+        ![
+          "application/octet-stream",
+          "application/pkcs8",
+          "application/pkix-cert",
+        ].includes(secret?.data?.content_types?.default)
+      ) {
+        // Handle payload types other than specific ones by returning as a string
+        setPayloadString(data)
+      } else {
+        // Handle specific payload types by downloading the content as a file
+>>>>>>> 716cc4a9b ([keymanagerng] Download payload file as a row file not a json file and show the content directly in the UI if the type is text/plain)
         const fileData = JSON.stringify(data)
         const blob = new Blob([fileData], {
           type: secret?.data?.content_types?.default,
@@ -192,11 +213,31 @@ const SecretDetails = () => {
                 <DataGridHeadCell>{"Payload"}</DataGridHeadCell>
                 <DataGridCell>
                   <div>
+<<<<<<< HEAD
                     <Button
                       icon="download"
                       label="Download"
                       onClick={handleDownload} // Trigger download on button click
                     />
+=======
+                    {[
+                      "application/octet-stream",
+                      "application/pkcs8",
+                      "application/pkix-cert",
+                    ].includes(secret?.data?.content_types?.default) ? (
+                      <Button
+                        icon="download"
+                        label="Download"
+                        onClick={handleDownload} // Trigger download on button click
+                      />
+                    ) : payloadString ? (
+                      // Show payload text if content types are not for downloading and payload exists
+                      <span>{payloadString}</span>
+                    ) : (
+                      // Show no payload message when no file to download and no payload text available
+                      <span>No payload available</span>
+                    )}
+>>>>>>> 716cc4a9b ([keymanagerng] Download payload file as a row file not a json file and show the content directly in the UI if the type is text/plain)
                   </div>
                 </DataGridCell>
               </DataGridRow>


### PR DESCRIPTION
# Summary

In the new key manager UI, the payload content encoding base64 was not displayed based on the selected payload content types. This commit fixes this issue in a way that for all secret types which offer payload content types of "application/pkcs8", "application/pkix-cert", "application/octet-stream", the payload content encoding will be  displayed and set to "base64", same as the old key manager app.

# Changes Made

1. NewSecretForm is updated to handle displaying and setting the correct payload content encoding based on the selected payload content type.
2. To add the Project ID alongside the Domain ID in the new Key Manager app same as all other extensions in elektra, I modified the `AjaxController`, which the `ApplicationController` was originally based on, and replaced it with `DashboardController`. This change ensures that the Project Id is available in the new Key Manager as well.

## Note for Reviewers:
Some changes in the diff of `newSecretForm` file are due to formatting and layout adjustments. The key modifications are:

**Lines 212–214:** Removed an unnecessary setFormData call that previously set the payload content encoding based on the secret type.
**Lines 369–371:** Moved and updated the logic to set the payload content encoding when the payload content type is selected.
**Line 391:** Added a check to display the payload content encoding text input and warning message when specific payload content types are selected.


# Related Issues
- Issue 1: [#ISSUE_ID](https://itsm.services.sap/now/nav/ui/classic/params/target/incident.do%3Fsys_id%3Da2ff1397c377161050f979f0e00131a4%26sysparm_view%3Dot)



# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
