### PR TITLE
chore(email-service): use maillog-ui from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@popperjs/core": "^2.11.6",
     "@rails/actioncable": "^7",
     "@sapcc/limes-ui": "^1.3.9",
+    "@sapcc/maillog-ui": "^1.0.25",
     "@tanstack/react-query": "^4.28.0",
     "ansi-up": "^1.0.0",
     "axios": "^0.21",

--- a/plugins/email_service/app/javascript/widgets/maillog-ui/init.js
+++ b/plugins/email_service/app/javascript/widgets/maillog-ui/init.js
@@ -1,0 +1,20 @@
+// The widget comes from the limes-ui package, which is a separate package from the elektra package.
+// https://github.com/sapcc/LimesUI
+// limes-ui implements the juno app interface which has the mount method.
+// The mount method is used to render the widget in the DOM.
+import { mount } from "@sapcc/maillog-ui"
+
+const currentScript = document.currentScript
+const wrapper = document.createElement("div")
+const dataset = currentScript.dataset
+wrapper.id = "maillog-ui"
+currentScript.replaceWith(wrapper)
+
+let props
+try {
+  props = JSON.parse(dataset?.props)
+} catch (e) {
+  props = {}
+}
+
+mount(wrapper, { props })

--- a/plugins/email_service/app/views/email_service/maillog/index.html.haml
+++ b/plugins/email_service/app/views/email_service/maillog/index.html.haml
@@ -4,16 +4,9 @@
 
 .tab-content
   .tab-pane.active{role:"tabpanel", id:"maillog-pane"}
-    :plain
-      <script
-        defer
-        src="https://assets.juno.#{qa? ? 'qa-de-1' : 'global'}.cloud.sap/apps/widget-loader@latest/build/app.js"
-        data-name="maillog"
-        data-version="latest"
-        data-props-get-token-func-name="_getCurrentToken"
-        data-props-theme="theme-light"
-        data-props-endpoint="https://maillog.#{current_region}.cloud.sap"
-        data-props-embedded="true"
-        data-props-project="#{@scoped_project_id}">
-      </script>
-    
+    = javascript_include_tag 'email_service_maillog-ui_widget', data: { props: { |
+      embedded: true,                                                    |
+      theme: 'theme-light',                                              |  
+      endpoint: "https://maillog.#{current_region}.cloud.sap",           |
+      "project": "#{@scoped_project_id}",                                |
+      "getTokenFuncName": "_getCurrentToken" } }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2214,6 +2214,15 @@
     react-day-picker "^9.0.0"
     react-router "^7.0.2"
 
+"@sapcc/maillog-ui@^1.0.25":
+  version "1.0.25"
+  resolved "https://npm.pkg.github.com/download/@sapcc/maillog-ui/1.0.25/f4aa43ffc945cd0ced6db77300eda6fe3d07ab51#f4aa43ffc945cd0ced6db77300eda6fe3d07ab51"
+  integrity sha512-6vzvoeTvj2ioPI0FmNsZassQccSGWo3X+4yONx7XGiLXw9s0lADawaj1Nl2+1aHthvPEQv5F0ojLB29CMztZbw==
+  dependencies:
+    datetimepicker "^0.1.39"
+    moment "^2.30.1"
+    node-fetch "^3.3.2"
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
@@ -3999,6 +4008,11 @@ date-fns@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
   integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
+datetimepicker@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/datetimepicker/-/datetimepicker-0.1.39.tgz#7b7f465dcc54bc7fc731cf3dcd8752bcfc69085a"
+  integrity sha512-CQOQRvEN4FThu5dXY4xNkqyiknJomafVC+muSJDbwYZQIrXU05yazPPRQXFYrAPFfr0I7n55kk2gCF39R2KsRQ==
 
 dayjs@^1.10.4:
   version "1.11.11"
@@ -6919,7 +6933,7 @@ minimist@^1.2.5, minimist@^1.2.8:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-moment@^2.29.2, moment@^2.29.4:
+moment@^2.29.2, moment@^2.29.4, moment@^2.30.1:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
@@ -6966,7 +6980,7 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^3.3.0:
+node-fetch@^3.3.0, node-fetch@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
   integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
@@ -8279,16 +8293,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8352,14 +8357,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9045,7 +9043,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9058,15 +9056,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
# Summary

This PR migrates the **maillog UI** dependency from **assets-server** to **npm**, in preparation for the **assets-server decommissioning**. The **maillog UI** is now published as an npm package on the GitHub registry under **@sapcc/maillog-ui**. Elektra has been adjusted to consume this package via npm.

# Changes Made

- Added **@sapcc/maillog-ui** to `package.json`
- Replaced the script tag source in the view to reference the local npm asset instead of the previous **assets-server** path.

# Related Issues

- [#643 ](https://github.com/orgs/sapcc/projects/5/views/6?sliceBy%5Bvalue%5D=Sprint+02%2F25&pane=issue&itemId=80869554&issue=sapcc%7Cjuno%7C643)
# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.