### PR TITLE
research(core): Integrate Action Mailer with Limes Email API 

### DIFF
--- a/app/mailers/core_application_mailer.rb
+++ b/app/mailers/core_application_mailer.rb
@@ -4,7 +4,6 @@ require 'json'
 
 class CoreApplicationMailer < ActionMailer::Base
   layout "mailer"
-  API_URL = 'https://limes-campfire.qa-de-1.cloud.sap/v1/send-email'.freeze
 
   def send_custom_email(recipient:, subject:, body_html:)
     # Get the token form the cloud_admin instance
@@ -14,7 +13,7 @@ class CoreApplicationMailer < ActionMailer::Base
     token = cloud_admin.instance_variable_get(:@api_client).token
         
     # Set up the UI
-    uri = URI.parse(API_URL)
+    uri = URI.parse(Rails.configuration.limes_mailer_address)
     uri.query = URI.encode_www_form({ from: 'elektra' })
    
     # Set up the body for the request

--- a/app/mailers/core_application_mailer.rb
+++ b/app/mailers/core_application_mailer.rb
@@ -1,0 +1,56 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+class CoreApplicationMailer < ActionMailer::Base
+  layout "mailer"
+  API_URL = 'https://limes-campfire.qa-de-1.cloud.sap/v1/send-email'.freeze
+
+  def send_custom_email(recipient:, subject:, body_html:)
+    # Get the token form the cloud_admin instance
+    ###################################
+    # TODO: add to the cloud_admin user "role:cloud_resource_admin or role:resource_service"
+    ###################################
+    token = cloud_admin.instance_variable_get(:@api_client).token
+        
+    # Set up the UI
+    uri = URI.parse(API_URL)
+    uri.query = URI.encode_www_form({ from: 'elektra' })
+   
+    # Set up the body for the request
+    body = {
+      recipients: [recipient],
+      subject: subject,
+      mime_type: 'text/html',
+      mail_text: body_html
+    }.to_json
+
+    # Set up headers
+    headers = {
+      'Content-Type' => 'application/json',
+      'X-Auth-Token' =>  token
+    }
+
+    # Create http client  
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    # Create the HTTP request
+    request = Net::HTTP::Post.new(uri, headers)
+    request.body = body
+
+    # Make the request and handle the response
+    response = http.request(request)
+
+    Rails.logger.info "Email API Response: #{response.code} - #{response.body}"
+  end
+
+  private
+
+  def cloud_admin
+    @cloud_admin ||=
+      Core::ServiceLayer::ServicesManager.new(
+        Core::ApiClientManager.cloud_admin_api_client,          
+      )
+  end
+
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -133,6 +133,7 @@ module MonsoonDashboard
     end
 
     # Mailer configuration for inquiries/requests
+    config.limes_mailer_address = ENV["LIMES_MAIL_SERVER"]
     config.action_mailer.raise_delivery_errors = true
     config.action_mailer.delivery_method = :smtp
     config.action_mailer.smtp_settings = {

--- a/plugins/access_profile/app/controllers/access_profile/tags_controller.rb
+++ b/plugins/access_profile/app/controllers/access_profile/tags_controller.rb
@@ -185,13 +185,13 @@ module AccessProfile
     end
 
     def restrict_access
+
       # just for production regions
       return if current_region.start_with?("qa-")
       # if user hasn't the cloud_support_tools_viewer should be redirected
       return if current_user.has_role?("cloud_support_tools_viewer")
 
-      @access_error = "You are not allowed to see this page."
-      render status: :unauthorized
+      render json: { error: "You are not allowed to see this page." }, status: :forbidden
     end
   end
 end

--- a/plugins/inquiry/app/mailers/inquiry/inquiry_mailer.rb
+++ b/plugins/inquiry/app/mailers/inquiry/inquiry_mailer.rb
@@ -1,5 +1,6 @@
 module Inquiry
-  class InquiryMailer < ApplicationMailer
+  class InquiryMailer < ::CoreApplicationMailer
+    
     def notification_email_requester(
       user_email,
       user_full_name,
@@ -81,7 +82,17 @@ module Inquiry
           subject += "/#{@inquiry.tags["domain_name"]}"
         end
       end
-      mail(to: inform_dl, subject: subject, content_type: "text/html")
+      
+      # Render the email body content
+      email_body = render_to_string('inquiry/inquiry_mailer/notification_new_project', layout: false)
+
+      send_custom_email(
+        recipient: inform_dl,
+        subject: subject,
+        body_html: email_body
+      )
+      # mail(to: inform_dl, subject: subject, content_type: "text/html")
     end
+
   end
 end


### PR DESCRIPTION
# Summary

This PR `showcases` how it could the limes Email API be integrated without having to redo the whole inquiry implementation. 

## TODOs
- Add to the `cloud_admin` the  `role:cloud_resource_admin or role:resource_service`
- Set the Limes Endpoint through a value

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Implemented a global ApplicationMailer to enable inheritance and provide the `send_custom_email` method.
- Changed to test notification_new_project method from the inquiry

# Related Issues

- #1517

# Screenshots (if applicable)

![Screenshot 2025-03-04 at 16 24 16](https://github.com/user-attachments/assets/6eb82aff-4b9a-43f3-821c-c21aab7c3b49)


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.
