### PR TITLE
fix(compute): check also locked attribute for server lock

### DIFF
--- a/plugins/compute/app/models/compute/server.rb
+++ b/plugins/compute/app/models/compute/server.rb
@@ -496,7 +496,7 @@ module Compute
     end
 
     def locked?
-      metadata.locked == true || metadata.locked == "true"
+      metadata.locked == true || metadata.locked == "true" || locked == true || locked == "true"
     end
 
     def lock


### PR DESCRIPTION
# Summary

* this will fix an issue that when a server was locked with the cli it was not recognized from elektra (when it was locked with elektra it was shown correctly)
* the reason was that the api send two `locked` attributes and only one was checked by elektra

if elektra lockes the server it looks like

````json
        "locked": true,
        "metadata": {
            "locked": "true"
        },
````
if the server was locked with cli it looks like
````json
        "locked": true,
        "metadata": {
            "locked": "false"
        },
````
elektra was only reading the metadata attribute

# Changes Made

* model function for `server.locked?` 

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
