### PR TITLE
chore(key-manager): make the 'new' UI default

### DIFF
--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -268,13 +268,13 @@ SimpleNavigation::Configuration.run do |navigation|
                                  highlights_on: %r{identity/projects/groups/?.*}
       access_management_nav.item :key_manager,
                                  'Key Manager',
-                                 -> { plugin('key_manager').secrets_path },
+                                 -> { plugin('keymanagerng').root_path },
                                  if: lambda {
-                                   plugin_available?(:key_manager)
+                                   plugin_available?(:keymanagerng)
                                  },
                                  highlights_on:
                                    proc {
-                                     params[:controller][%r{key_manager/.*}]
+                                     params[:controller][%r{keymanagerng/.*}]
                                    }
     end
 


### PR DESCRIPTION
# Summary

Set the new Key Manager UI as the default option. The current interface still includes a note with a link to the old UI, allowing users to switch back if needed. Our goal is to gather more feedback from customers and address potential bugs. Eventually, we can consider removing the old UI completely.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
