### PR TITLE
feat(core): first working version of identity federation

### DIFF
--- a/app/controllers/auth_token_controller.rb
+++ b/app/controllers/auth_token_controller.rb
@@ -31,13 +31,12 @@ class AuthTokenController < ActionController::Base
 
       if response.is_a?(Net::HTTPSuccess)
         response_body = JSON.parse(response.body)
-        domain_id = response_body.dig('token', 'user', 'domain', 'id')
+        domain_name = response_body.dig('token', 'user', 'domain', 'name')
 
-        if domain_id
+        if domain_name
           # Render the loading view while processing the redirect
-          @domain_id = domain_id
+          @domain_name = domain_name
           @auth_token = encode_auth_token(token)
-          # render :redirect_form, locals: { domain_id: @domain_id, auth_token: @auth_token } and return
           render :redirect and return
         else
           @error = 'Domain ID not found in response'
@@ -67,7 +66,7 @@ class AuthTokenController < ActionController::Base
 
   def allowed_origin?
     # Define your trusted domains
-    trusted_origins = [KEYSTONE_ENDPOINT]
+    trusted_origins = ["https://identity-3.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap"]
 
     # Check the Origin header
     origin = request.headers['Origin']

--- a/app/views/monsoon_openstack_auth/sessions/_federation.html.haml
+++ b/app/views/monsoon_openstack_auth/sessions/_federation.html.haml
@@ -2,15 +2,12 @@
 - auth_url="https://identity-3.#{current_region}.cloud.sap/v3/auth/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/websso?origin=https://dashboard.#{current_region}.cloud.sap/verify-auth-token"
 
 .form-signin
-    %h5.form-signin-heading
-        Federated login
-    %a.btn.btn-lg.btn-primary.btn-block{ href:auth_url, onclick: "storeCurrentUrl"} Please sign in
+    .bs-callout.bs-callout-info.bs-callout-emphasize
+        Click the "Sign In with Identity Provider" button to initiate the authentication process, and after a successful login, you will be redirected back to your dashboard.
+    %a.btn.btn-lg.btn-primary.btn-block{ href:auth_url, onclick: "storeCurrentUrl"} Sign In with Identity Provider
 
 :javascript
     //function which is called onclick and store the current url in local storage
     function storeCurrentUrl(e){
         localStorage.setItem("after_login", "#{params[:after_login]}");
-        // for testing
-        // console.log(localStorage.getItem("after-login"));
-        // e.preventDefault();
     } 

--- a/config/support/domain_config.yaml
+++ b/config/support/domain_config.yaml
@@ -23,3 +23,7 @@ domains:
     dns_c_subdomain: false
     # set this to use the federation feature in keystone
     federation: false
+
+  - name: iaas
+    regex: "iaas-.*"
+    federation: true  

--- a/config/support/domain_config.yaml
+++ b/config/support/domain_config.yaml
@@ -23,7 +23,3 @@ domains:
     dns_c_subdomain: false
     # set this to use the federation feature in keystone
     federation: false
-
-  - name: iaas
-    regex: "iaas-.*"
-    federation: true  


### PR DESCRIPTION
# Summary

This pull request introduces the initial working implementation of Keystone Federated Authentication. A new view has been created to display a sign-in button for federation, and a corresponding endpoint has been established to receive the authentication token via POST from the Identity Provider.

# Changes Made

- **Enhanced Authentication Views**: Introduced a new template: `_federation.html.haml` for the sign-in interface.
- **New Controller Added**: Implemented `auth_token.rb` to handle the reception and verification of the token from the Identity Provider.
- **Additional Views Created**: Developed supplementary views to support the functionality of the `auth_token` controller.
- 
# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
