### PR TITLE
feat(config): added "persephone" cloud-level roles to blocklist

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -55,4 +55,6 @@ BLACKLISTED_ROLES = %w[
   cloud_objectstore_viewer
   cloud_masterdata_admin
   cloud_masterdata_viewer
+  cloud_persephone_admin
+  cloud_persephone_viewer
 ].freeze


### PR DESCRIPTION
# Summary

[Persephone](https://github.wdf.sap.corp/cc/persephone/) (private repo) is a new project/service meant to serve as an "API proxy" to the Gardener API, so that customers can easily set up new Shoots in SCI in a couple straight-forward steps. This change ensures the cloud-level roles needed for its Oslo policy are not available for assigning to users inside the Elektra UI (these should be managed by CAM soon).

# Changes Made

Included the cloud-level roles in the block-list. 

# Related Issues

None.

# Screenshots (if applicable)

None.

# Checklist

- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [X] I have made corresponding changes to the documentation (if applicable).
- [X] My changes generate no new warnings or errors.
