### PR TITLE
chore(core): fix deep links for federated login

### DIFF
--- a/app/controllers/auth_token_controller.rb
+++ b/app/controllers/auth_token_controller.rb
@@ -21,6 +21,9 @@ class AuthTokenController < ActionController::Base
     # Set up the HTTP connection
     http = Net::HTTP.new(url.host, url.port)
     http.use_ssl = true if url.scheme == 'https'
+    if ENV['ELEKTRA_SSL_VERIFY_PEER'] == 'false'
+      http.verify_mode = 0
+    end
 
     request = Net::HTTP::Get.new(url)
     request['X-Subject-Token'] = token
@@ -56,6 +59,12 @@ class AuthTokenController < ActionController::Base
   protected
 
   def verify_authenticity_token
+    # for debugging comment out to disable CSRF protection for this action
+    if Rails.env.development? || Rails.env.test?
+      # Disable CSRF protection in development/test environments
+      return true
+    end
+
     # Call the original method to maintain normal CSRF checking
     super unless allowed_origin?
 

--- a/app/views/auth_token/redirect.html.haml
+++ b/app/views/auth_token/redirect.html.haml
@@ -7,7 +7,7 @@
     .spinner    
 
 :javascript
-  const after_login = "/#{@domain_name}/home";
+  let after_login = "/#{@domain_name}/home";
   // try to get the after_login from the localStorage
   if (localStorage.getItem('after_login')) {
     after_login = localStorage.getItem('after_login');

--- a/app/views/monsoon_openstack_auth/sessions/_federation.html.haml
+++ b/app/views/monsoon_openstack_auth/sessions/_federation.html.haml
@@ -1,10 +1,12 @@
 - current_region=ENV["MONSOON_DASHBOARD_REGION"]
-- auth_url="https://identity-3.#{current_region}.cloud.sap/v3/auth/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/websso?origin=https://dashboard.#{current_region}.cloud.sap/verify-auth-token"
+- auth_url=ENV["FEDERATION_AUTH_URL"]
+- if auth_url.nil?
+    - auth_url="https://identity-3.#{current_region}.cloud.sap/v3/auth/OS-FEDERATION/identity_providers/sap-ias/protocols/openid/websso?origin=https://dashboard.#{current_region}.cloud.sap/verify-auth-token"
 
 .form-signin
     .bs-callout.bs-callout-info.bs-callout-emphasize
         Click the "Sign In with Identity Provider" button to initiate the authentication process, and after a successful login, you will be redirected back to your dashboard.
-    %a.btn.btn-lg.btn-primary.btn-block{ href:auth_url, onclick: "storeCurrentUrl"} Sign In with Identity Provider
+    %a.btn.btn-lg.btn-primary.btn-block{ href:auth_url, onclick: "storeCurrentUrl()"} Sign In with Identity Provider
 
 :javascript
     //function which is called onclick and store the current url in local storage


### PR DESCRIPTION
# Summary

* this will fix the logic for deep links after the user logged in via federation
* it will also add the possibility to add a custom `auth_url` for the federated login
* contains some adjustments to run the federation in development mode

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
