### PR TITLE
fix(identity): display missing LBaaS roles in user role assignments

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -14,6 +14,9 @@ ALLOWED_ROLES = %w[
   keymanager_viewer
   kubernetes_admin
   kubernetes_member
+  loadbalancer_admin
+  loadbalancer_viewer
+  loadbalancer_poolmemberadmin
   member
   masterdata_admin
   masterdata_viewer

--- a/plugins/identity/config/locales/en.yml
+++ b/plugins/identity/config/locales/en.yml
@@ -30,6 +30,9 @@ en:
     image_viewer: Glance Read-Only
     keymanager_admin: Barbican Administrator
     keymanager_viewer: Barbican Read-Only
+    loadbalancer_admin: Load Balancer Administrator
+    loadbalancer_viewer: Load Balancer Read-Only
+    loadbalancer_poolmemberadmin: Load Balancer Pool Member Administrator
     masterdata_admin: Master Data Administrator
     masterdata_viewer: Master Data Read-Only
     member: Member


### PR DESCRIPTION
# Summary

This PR adds support for displaying missing LBaaS roles in the user role assignments view.

# Changes Made

- Added missing roles to the `ALLOWED_ROLES` list:
  - `loadbalancer_admin`
  - `loadbalancer_viewer`
  - `loadbalancer_poolmemberadmin`
- Added corresponding locale entries for the new role keys

# Related Issues

- Fixes #1566

# Screenshots (if applicable)

![Screenshot 2025-04-29 at 09 06 38](https://github.com/user-attachments/assets/db206ac3-05d0-4234-ad13-c3cc2b3621be)

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
