### PR TITLE
fix(ui): fix configuration descriptions for minimum free critical

### DIFF
--- a/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
+++ b/plugins/shared_filesystem_storage/app/javascript/widgets/app/components/castellum/configuration/view.jsx
@@ -54,7 +54,7 @@ export default class CastellumConfigurationView extends React.Component {
               Shares will be extended when usage exceeds{" "}
               <strong>{percent(config.high_threshold.usage_percent)}</strong>{" "}
               {config.size_constraints &&
-                config.size_constraints.minimum_free && (
+                config.size_constraints.minimum_free && !config.size_constraints.minimum_free_is_critical && (
                   <>
                     (or when free space is below{" "}
                     <strong>{config.size_constraints.minimum_free} GiB</strong>)
@@ -64,12 +64,24 @@ export default class CastellumConfigurationView extends React.Component {
               <strong>{duration(config.high_threshold.delay_seconds)}</strong>.
             </li>
           )}
-          {config.critical_threshold && (
+          {(config.critical_threshold || config.size_constraints.minimum_free_is_critical) && (
             <li>
-              Shares will be extended immediately when usage exceeds{" "}
-              <strong>
-                {percent(config.critical_threshold.usage_percent)}
-              </strong>
+              Shares will be extended immediately{" "}
+              {config.critical_threshold &&
+                <>
+                  when usage exceeds{" "}
+                    <strong>
+                      {percent(config.critical_threshold.usage_percent)}{" "}
+                    </strong>
+                </>
+              }
+              {config.size_constraints.minimum_free_is_critical && 
+                <>
+                  {config.critical_threshold && <>or {" "}</>}
+                  when free space is below{" "}
+                    <strong>{config.size_constraints.minimum_free} GiB</strong>
+                </>
+              }
               .
             </li>
           )}
@@ -113,11 +125,6 @@ export default class CastellumConfigurationView extends React.Component {
                 ...never below{" "}
                 <strong>{config.size_constraints.minimum_free} GiB</strong> of
                 free space.
-              </li>
-            )}
-            {config.size_constraints.minimum_free_is_critical && (
-              <li>
-                ...resize without delay.
               </li>
             )}
           </ul>


### PR DESCRIPTION
# Summary

The descriptions for the option "min_free_is_critical" were not helpful for the user. This gets changed in this PR.

# Changes Made

- Instead of "...resize without delay." the information will be present at the "Autoscaling is enabled:" part of the configuration description. Specifically included in the "Shares will be extended immediately when [...]" section.

# Screenshots (if applicable)

How it was previously:
![image](https://github.com/user-attachments/assets/1d83b28d-b794-431d-9acd-c1199354cbf8)

How the description looks like now if critical treshold is enabled in conjuction with "min_free_is_critical":
![image](https://github.com/user-attachments/assets/a9d0404a-7ea7-4cea-bff9-af14502b688f)

How the description looks now if only "min_free_is_critical" is set:
![image](https://github.com/user-attachments/assets/8f0e41a5-4a56-414d-9e11-727c047db9bd)

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
