### PR TITLE
chore(ci): add permissions to workflows

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -103,7 +103,7 @@ jobs:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Yarn install
+      - name: Install packages and run tests
         # this runs only in PRs from the same repo because of the missing npm token to download the packages
         if: |
           github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,6 +14,9 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/pr-title-lint-check.yaml
+++ b/.github/workflows/pr-title-lint-check.yaml
@@ -8,6 +8,10 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  pull-requests: read
+  contents: read
+
 jobs:
   title-lint:
     name: Validate title


### PR DESCRIPTION
# Summary

this PE will add permissions to workflows to get rid of the warnings that the workflows are running without permissions

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
