### PR TITLE
feat(keppel): introduce validation rules for manifest

### DIFF
--- a/plugins/keppel/app/javascript/widgets/app/actions/keppel.js
+++ b/plugins/keppel/app/javascript/widgets/app/actions/keppel.js
@@ -69,7 +69,6 @@ export const putAccount =
           resolve(newAccount)
         })
         .catch((error) => {
-          showError(error)
           reject({ errors: errorMessage(error) })
         })
     )

--- a/plugins/keppel/app/javascript/widgets/app/components/validation_rules/edit.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/validation_rules/edit.jsx
@@ -1,18 +1,20 @@
 import { Modal, Button } from "react-bootstrap"
 import { Form } from "lib/elektra-form"
+import { FormErrors } from "lib/elektra-form/components/form_errors"
 import React from "react"
 import { apiStateIsDeleting } from "../utils"
 
 export default class RBACPoliciesEditModal extends React.Component {
   state = {
     show: true,
+    apiError: null,
   }
 
   close = (e) => {
     if (e) {
       e.stopPropagation()
     }
-    this.setState({ ...this.state, show: false })
+    this.setState({ ...this.state, show: false, apiError: null })
     setTimeout(() => this.props.history.replace("/accounts"), 300)
   }
 
@@ -27,7 +29,15 @@ export default class RBACPoliciesEditModal extends React.Component {
         rule_for_manifest: requiredLabelsStr,
       },
     }
-    return this.props.putAccount(newAccount).then(() => this.close())
+    this.props
+      .putAccount(newAccount)
+      .then(() => this.close())
+      .catch((error) => {
+        this.setState({
+          ...this.state,
+          apiError: error,
+        })
+      })
   }
 
   render() {
@@ -69,6 +79,7 @@ export default class RBACPoliciesEditModal extends React.Component {
           initialValues={initialValues}
         >
           <Modal.Body>
+            {this.state.apiError && <FormErrors errors={this.state.apiError} />}
             <Form.ElementHorizontal label="Rule" labelWidth={1} name="rule_for_manifest">
               <Form.Input elementType="input" type="text" name="rule_for_manifest" readOnly={!isAdmin} />
               <div className="form-control-static tw-mt-2">


### PR DESCRIPTION
# Summary

Keppel is undergoing a change in how restrictions to an account can be set. Instead of limiting the options to checking for valid image labels, other limiting factors should be possible as well. Setting the repo_name is one of those options that are currently available. Because of this, the naming, description, and object attributes need to be adjusted.

# Changes Made

<!-- List the changes that were made in this pull request. -->

- Adjust the validation field naming
- Adjust the configuration information
- Adjust the configuration attribute
- Make errors in account changes visible to the user

# Screenshots (if applicable)

Example configuration:
<img width="1806" height="1034" alt="image" src="https://github.com/user-attachments/assets/1daef8f7-8f69-4e57-9efa-b2722e13b79f" />

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
