### PR TITLE
chore(key-manager): removes secret text to display payload

### DIFF
--- a/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/secrets/secretDetails.jsx
@@ -10,7 +10,6 @@ import {
   DataGridCell,
   DataGridHeadCell,
   CodeBlock,
-  SecretText,
   Badge,
   Button,
 } from "@cloudoperators/juno-ui-components"
@@ -39,7 +38,6 @@ const SecretDetails = () => {
   const history = useHistory()
   const params = useParams()
   const [secretId, setSecretId] = useState(null)
-  const [payloadString, setPayloadString] = useState("")
   const [creatorName, setCreatorName] = useState(null)
   const [secretMetadata, setSecretMetadata] = useState(null)
   const [payloadRequested, setPayloadRequested] = useState(false)
@@ -99,9 +97,6 @@ const SecretDetails = () => {
     setShow(!!params.id)
   }, [params.id])
 
-  const isPayloadContentTypeTextPlain = (contentType) => {
-    return contentType?.includes("text/plain")
-  }
 
   const secretPlayload = useQuery({
     queryKey: [
@@ -110,14 +105,8 @@ const SecretDetails = () => {
       secret?.data?.content_types?.default,
     ],
     queryFn: getSecretPayload,
-    enabled:
-      payloadRequested || // Enable when download requested
-      (!!secretId &&
-        isPayloadContentTypeTextPlain(secret?.data?.content_types?.default)), // Enable for text/plain content types when panel is shown,
+    enabled: payloadRequested, // Only enable when download is requested
     onSuccess: (data) => {
-      if (isPayloadContentTypeTextPlain(secret?.data?.content_types?.default)) {
-        setPayloadString(data)
-      }
       if (payloadRequested) {
         //Downloading the payload content as a file, put the raw data into a blob
         const blob = new Blob([data], {
@@ -245,20 +234,6 @@ const SecretDetails = () => {
                 </DataGridCell>
               </DataGridRow>
             </DataGrid>
-            {isPayloadContentTypeTextPlain(
-              secret?.data?.content_types?.default
-            ) && (
-              <>
-               {payloadString && (
-                <SecretText
-                  label="Payload"
-                  disableClear
-                  disablePaste
-                  value={payloadString}
-                />
-               )}
-              </>
-            )}
             {metadata?.isLoading && !metadata?.data ? (
               <HintLoading />
             ) : metadata?.data ? (


### PR DESCRIPTION
# Summary

Remove secret text to display payload from Secret Details panel to improve security and compliance by preventing accidental payload content requests. Secret payloads will now only be fetched when users explicitly request them via the download button.

# Changes Made

- Removed SecretText component import and usage from secretDetails.jsx
- Removed automatic payload fetching for text/plain content types on component mount
- Modified secretPlayload useQuery to only execute when download is explicitly requested (payloadRequested state)
- Removed payloadString state variable and isPayloadContentTypeTextPlain helper function

# Related Issues

- Issue 1: closes #1766 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
