### PR TITLE
fix(core): collect all paths in metrics

### DIFF
--- a/app/middleware/sli_metrics_middleware.rb
+++ b/app/middleware/sli_metrics_middleware.rb
@@ -23,7 +23,6 @@ class SLIMetricsMiddleware
     if should_skip_path?(path_info)
       return @app.call(env)
     end
-    pp "=============================="
     # Extract domain (first path segment)
     domain = extract_domain(path_info)
     


### PR DESCRIPTION
This PR fixes a bug in the metrics collector. Previously, all paths after the domain /DOMAIN/* were ignored. Now, we consider all paths but label the metrics only with the domain for performance reasons.

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
