### PR TITLE
fix(identity): this will disable add button if no user was found

### DIFF
--- a/app/javascript/lib/components/autocomplete_field.jsx
+++ b/app/javascript/lib/components/autocomplete_field.jsx
@@ -25,7 +25,7 @@ export class AutocompleteField extends React.Component {
   // this is used to enable/disable the add button in the parent component
   // to prevent adding non-existing users
   handleChange = (selected) => {
-    const isValid = selected && selected.length > 0
+    const isValid = selected && selected?.length > 0
     this.setState({ isValid })
 
     if (this.props.onSelected) {

--- a/plugins/identity/app/javascript/widgets/role_assignments/components/project_role_assignments.jsx
+++ b/plugins/identity/app/javascript/widgets/role_assignments/components/project_role_assignments.jsx
@@ -35,10 +35,6 @@ export default class ProjectRoleAssignments extends React.Component {
 
   // this function handles the selection of a new member in the autocomplete field
   handleNewMember = (member, isValid) => {
-    // if isValid is defined, use it
-    // otherwise, determine validity based on member type
-    let validMember = isValid !== undefined ? isValid : false
-
     // if an array is given, take the first element and ignore the rest
     if (Array.isArray(member)) member = member[0]
 
@@ -64,7 +60,7 @@ export default class ProjectRoleAssignments extends React.Component {
           name: member.name,
           description: member.full_name || member.description,
         },
-        isValidMember: validMember !== undefined ? validMember : true,
+        isValidMember: isValid,
       })
     } else {
       this.setState({ newMember: null, isValidMember: false })


### PR DESCRIPTION
# Summary

* this will fix the issue that the `Add` Button in Role Assignments is not disabled when no valid user was found

# Related Issues

- fixes: #1814

# Screenshots

<img width="508" height="125" alt="image" src="https://github.com/user-attachments/assets/5c7a2ab4-34bd-42c0-a3dc-61cdd21b7fa6" />

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
