### PR TITLE
feat(core): handle tab closing event on the dedicated web shell page

### DIFF
--- a/plugins/webconsole/app/javascript/global/webconsole_container.js
+++ b/plugins/webconsole/app/javascript/global/webconsole_container.js
@@ -201,6 +201,7 @@ var WebconsoleContainer = (function () {
     }
 
     static addUnloadHandler() {
+      if (this.unloadHandler) return
       // Protect against accidental browser tab closure while webconsole is active
       // Problem: Users working in the web terminal often use keyboard shortcuts,
       // and it's easy to accidentally hit Cmd+W (Mac) or Ctrl+W (Windows/Linux)
@@ -342,6 +343,12 @@ var WebconsoleContainer = (function () {
                 }
 
                 $loadingHint.remove()
+
+                // Add beforeunload handler when webconsole opens
+                // This prevents users from accidentally closing the browser tab with Cmd+W/Ctrl+W
+                // while working in the web console, which would lose their active terminal session
+                // and any unsaved work or running commands
+                WebconsoleContainer.addUnloadHandler()
 
                 return (self.loaded = true)
               },


### PR DESCRIPTION
This pull request completes the feature that prevents the current browser tab from closing when the user presses CMD+W while using the web console. With this change, closing the tab via the CMD+W shortcut is disabled within the web console context, ensuring uninterrupted workflow and reducing accidental tab closures during console use.

fixes: #1793 
# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
