### PR TITLE
fix(object-storage): load next objects while length is > 0

### DIFF
--- a/plugins/object_storage/app/javascript/widgets/app/hooks/useActions.js
+++ b/plugins/object_storage/app/javascript/widgets/app/hooks/useActions.js
@@ -132,9 +132,10 @@ const useActions = () => {
           .then((response) => {
             data = [...data, ...response.data]
             headers = response.headers
+
             if (response.data.length > 0) {
               marker = response.data[response.data.length - 1].name
-              hasMore = response.data.length > 9999
+              hasMore = true
             } else {
               hasMore = false
             }


### PR DESCRIPTION
# Fix: Users Unable to Find Objects Due to Incomplete Pagination

## Problem
Users were unable to find objects in containers because the pagination logic was terminating prematurely. The previous implementation would stop fetching additional pages when it received exactly 9999 items, causing objects beyond that threshold to be inaccessible.

## Solution
Fixed the pagination logic to continue fetching until the API returns an empty response, indicating there are no more objects to retrieve.

## Changes

**Before:**
```javascript
hasMore = response.data.length > 9999
```
**After:**
```javascript
hasMore = true
```


# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
