### PR TITLE
fix(keppel): label line break

### DIFF
--- a/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
+++ b/plugins/keppel/app/javascript/widgets/app/components/images/row.jsx
@@ -30,20 +30,18 @@ const mediaTypes = {
 const renderLabel = (key, value) => {
   const isLink = /^https?:\/\//.test(value)
   let label = (
-    <span key={key} className={isLink ? "label label-primary" : "label label-default"}>
-      <span className="image-label-key">{key}:</span> <span className="image-label-value">{value}</span>
+    <span className={isLink ? "label label-primary" : "label label-default"}>
+      <span className="image-label-key">{key}:</span>
+      <span className="image-label-value">{value}</span>
     </span>
   )
   if (isLink) {
-    label = (
-      <a key={key} href={value}>
-        {label}
-      </a>
-    )
+    label = <a href={value}>{label}</a>
   }
+
   //the labels have `white-space:nowrap` inside, so some extra whitespace is
   //required to allow long lines with lots of labels to break
-  return label
+  return <React.Fragment key={key}>{label}&#32;</React.Fragment>
 }
 
 export default class ImageRow extends React.Component {


### PR DESCRIPTION
# Summary

The latest Keppel change caused the image labels to have a line break. This reverts the change and aims to make the intention of the line-breaking comment above the label return value more clear.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
