### PR TITLE
fix(networking): do not compare ipv4 with ipv6

### DIFF
--- a/plugins/compute/app/controllers/compute/instances_controller.rb
+++ b/plugins/compute/app/controllers/compute/instances_controller.rb
@@ -936,15 +936,18 @@ module Compute
                 ) unless subnets[subid]
                 sub = subnets[subid]
                 cidr = NetAddr.parse_net(sub.cidr)
-                if cidr.contains(NetAddr.parse_ip(fip.floating_ip_address))
+                parsed_fip = NetAddr.parse_ip(fip.floating_ip_address)
+                # Check if both are the same IP version before comparing
+                # It can happen that CIDR is IPv4 and IP is IPv6 and vice versa
+                if cidr.version == parsed_fip.version && cidr.contains(parsed_fip)
                   @grouped_fips[sub.name] ||= []
-                  @grouped_fips[sub.name] << fip #[fip.floating_ip_address, fip.id]
+                  @grouped_fips[sub.name] << fip
                   break
                 end
               end
             else
               @grouped_fips[net.name] ||= []
-              @grouped_fips[net.name] << fip #[fip.floating_ip_address, fip.id]
+              @grouped_fips[net.name] << fip
             end
           end
         end


### PR DESCRIPTION
# Summary

* this will handle an error in attach fip dialog where ipv4 and ipv6 cidr ranges and addresses where compared 

# Related Issues

- closes issue: #1840  

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
