### PR TITLE
chore(lbaas): normalize API errors to always return render-safe strings

### DIFF
--- a/plugins/lbaas2/app/javascript/widgets/app/helpers/commonHelpers.test.jsx
+++ b/plugins/lbaas2/app/javascript/widgets/app/helpers/commonHelpers.test.jsx
@@ -1,0 +1,115 @@
+import { normalizeError } from "./commonHelpers.jsx"
+
+describe("normalizeError", () => {
+  it("handles serialized server error", () => {
+    const error = {
+      data: {
+        message: ", , Forbidden action",
+      },
+      __isServerError: true,
+    }
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "API Error",
+      message: "Forbidden action",
+    })
+  })
+
+  it("handles error object (data.error)", () => {
+    const error = {
+      data: {
+        error: {
+          code: 403,
+          title: "Forbidden",
+          description: "You are not authorized",
+        },
+      },
+    }
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "API Error",
+      message: "You are not authorized",
+    })
+  })
+
+  it("handles errors array (data.errors)", () => {
+    const error = {
+      data: {
+        errors: [{ message: "Not authorized" }, { message: "Policy violation" }],
+      },
+    }
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "API Error",
+      message: "Not authorized, Policy violation",
+    })
+  })
+
+  it("handles native Error instance", () => {
+    const error = new Error("Something went wrong")
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "Error",
+      message: "Something went wrong",
+    })
+  })
+
+  it("handles native Error without message", () => {
+    const error = new Error("")
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "Error",
+      message: "An unknown error occurred.",
+    })
+  })
+
+  it("handles string error", () => {
+    const error = "Plain string error"
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "Error",
+      message: "Plain string error",
+    })
+  })
+
+  it("handles unknown object error", () => {
+    const error = { foo: "bar" }
+
+    const result = normalizeError(error)
+
+    expect(result).toEqual({
+      title: "Unknown Error",
+      message: "An unexpected error occurred. Please try again.",
+    })
+  })
+
+  it("handles null error", () => {
+    const result = normalizeError(null)
+
+    expect(result).toEqual({
+      title: "Unknown Error",
+      message: "An unexpected error occurred. Please try again.",
+    })
+  })
+
+  it("handles undefined error", () => {
+    const result = normalizeError(undefined)
+
+    expect(result).toEqual({
+      title: "Unknown Error",
+      message: "An unexpected error occurred. Please try again.",
+    })
+  })
+})


### PR DESCRIPTION
# Summary

The UI could crash when API calls (e.g. Barbican 403 responses) returned structured error payloads.  
These payloads were sometimes stored directly in state and rendered, leading to runtime errors such as:

> Objects are not valid as a React child

# Changes Made

- Introduced a centralized `normalizeError` helper
- Normalizes different error shapes (Barbican/OpenStack, serialized loader errors, native `Error`) into a consistent structure
- Guarantees that user-facing error messages are always strings
- Updated `errorMessage` to delegate to `normalizeError`
- Added unit tests covering all supported error cases

# Related Issues

- #1865 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
