### PR TITLE
fix(core): improve CSRF handling and URL validation in session actions

### DIFF
--- a/plugins/monsoon-openstack-auth/app/controllers/monsoon_openstack_auth/sessions_controller.rb
+++ b/plugins/monsoon-openstack-auth/app/controllers/monsoon_openstack_auth/sessions_controller.rb
@@ -18,8 +18,6 @@ module MonsoonOpenstackAuth
     # Skipping CSRF for login endpoints is safe because:
     # - Login forms don't have an authenticated session to protect against CSRF attacks
     # - Same-origin policy prevents cross-site form submissions
-    # - This is a common pattern for login endpoints in Rails applications
-    # See also: PR #1837 which fixed a similar CSRF issue caused by session rescoping
     skip_before_action :verify_authenticity_token, only: %i[create consume_auth_token check_passcode]
 
     before_action :load_auth_params, except: %i[destroy consume_auth_token]


### PR DESCRIPTION
# Summary

Fixes intermittent CSRF token validation errors on the "Sync Password" flow by skipping CSRF verification for login endpoints, and adds consistent `safe_redirect_url?` validation to prevent open redirect vulnerabilities.

## Problem

Users clicking "Sync Password" in their profile intermittently encountered a "Can't verify CSRF token authenticity" error (HTTP 422). The issue only affected the "Sync Password" flow (users with existing sessions), not fresh logins.

### Root Cause

When a user with an existing session visits the login page, `AuthSession.logout()` calls `reset_session()` plugins/monsoon-openstack-auth/app/controllers/monsoon_openstack_auth/sessions_controller.rb:

```ruby
def reset_session(controller)
  token_store = token_store(controller)
  return unless token_store        # ← Returns early if no session (fresh login)

  dump = token_store.dump          # Save OpenStack tokens
  controller.send('reset_session') # Clears session INCLUDING CSRF token
  token_store.restore(dump)        # Restores OpenStack tokens, NOT CSRF token
end
```

The flow:

1. **Fresh login** (no session): `token_store` returns `nil` → `reset_session` returns early → CSRF works ✅
2. **Sync Password** (has session): `reset_session` runs fully → new session ID created → new CSRF token generated → but due to session management complexity (ActiveRecord store, domain-scoped cookie paths), the token can become invalid between form render and submit ❌ 

## Solution

1. **Skip CSRF verification for login actions** (`create`, `consume_auth_token`, `check_passcode`)
   - Login forms don't have an authenticated session to protect
   - Same-origin policy prevents cross-site form submissions
   - This is a common pattern for login endpoints in Rails applications

2. **Add `safe_redirect_url?` validation** to `create`, `check_passcode`, and `destroy` actions
   - Prevents open redirect vulnerabilities
   - Only allows relative URLs or same-host URLs
   - Already used in `consume_auth_token`, now applied consistently

## Changes Made

- Add `skip_before_action :verify_authenticity_token` for login-related actions
- Apply `safe_redirect_url?` validation to `after_login` and `redirect_to` parameters in all actions
- Make host comparison case-insensitive in `safe_redirect_url?`

## Flow Diagram

```
FRESH LOGIN (no session)                 SYNC PASSWORD (has session)
        │                                         │
        ▼                                         ▼
  reset_session()                           reset_session()
        │                                         │
        ▼                                         ▼
  token_store = nil                         token_store exists
        │                                         │
        ▼                                         ▼
  return early ◄─ NO RESET                  controller.reset_session
        │                                         │
        ▼                                         ▼
  Form + CSRF token                         NEW session + NEW CSRF token
        │                                         ▼
        ▼                                   Session management complexity
  Submit → Token matches ✅                 (ActiveRecord store, cookie paths)
                                                  │
                                                  ▼
                                            Submit → Token may not match ❌
```

# Related Issues

-  Could fix Issue: #1813 

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.