### PR TITLE
chore(key-manager): opens order details panel after creating an order

### DIFF
--- a/plugins/keymanagerng/app/javascript/widgets/app/components/orders/newOrder.jsx
+++ b/plugins/keymanagerng/app/javascript/widgets/app/components/orders/newOrder.jsx
@@ -30,7 +30,7 @@ const NewOrder = () => {
       variant: "success",
       text: `The order ${orderUuid} is successfully created.`,
     })
-  }, [history])
+  }, [])
 
   useEffect(() => {
     setShowNewOrder(true)


### PR DESCRIPTION
# Summary

After creating an order, the order details panel is opened automatically so the user can immediately see whether the secret for that order has been created. This improves the current UX; a larger redesign (breadcrumbs and full pages instead of panels) is planned for Aurora.

# Changes Made

- Open the order details panel right after an order is created
- Show the created order’s details panel so users can check secret creation status without manual navigation

# Related Issues

- Issue 1: closes #1877 

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
