### PR TITLE
fix(cypress): remove unnecessary wait 

### DIFF
--- a/e2e/cypress/integration/admin/domain.js
+++ b/e2e/cypress/integration/admin/domain.js
@@ -15,10 +15,6 @@ describe("domain landing page", () => {
   it("open domain landing page and check logout button", () => {
     cy.contains("a.navbar-identity", "Technical Team User").click()
     cy.contains("a", "Log out").click()
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500)
-    // check not in one string because it can be different order
-    cy.contains("button", "Enter CC3TEST")
   })
 
   it("open domain landing page open and create project dialog", () => {

--- a/e2e/cypress/integration/admin/project.js
+++ b/e2e/cypress/integration/admin/project.js
@@ -18,10 +18,6 @@ describe("project landing page", () => {
     cy.visit(`/${TEST_DOMAIN}/admin/identity/project/home`)
     cy.contains("a.navbar-identity", "Technical Team User").click()
     cy.contains("a", "Log out").click()
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500)
-    // check not in one string because it can be different order
-    cy.contains("button", "Enter CC3TEST")
   })
 
   it("open project landing page and check delete project panel is loading", () => {

--- a/e2e/cypress/integration/member/project.js
+++ b/e2e/cypress/integration/member/project.js
@@ -38,9 +38,5 @@ describe("project landing page", () => {
     cy.visit(`/${TEST_DOMAIN}/test/identity/project/home`)
     cy.contains("a.navbar-identity", "Technical Team User").click()
     cy.contains("a", "Log out").click()
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(500)
-    // check not in one string because it can be different order
-    cy.contains("button", "Enter CC3TEST")
   })
 })


### PR DESCRIPTION
# Summary

* remove unnecessary wait  and assertions from logout button checks
* this will fix 3 cypress tests

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
