### PR TITLE
refactor(kubernetes): centralize landscape config and simplify navigation

### DIFF
--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -123,10 +123,13 @@ SimpleNavigation::Configuration.run do |navigation|
                      # Show if old kubernetes (kubernikus) is available
                      (plugin_available?(:kubernetes) && current_user &&
                        current_user.has_service?('kubernikus')) ||
-                     # Or if any kubernetes_ng landscape is available
+                     # Or if any kubernetes_ng landscape is available with correct conditions
                      (plugin_available?(:kubernetes_ng) && (
-                       services.available?(:kubernetes_ng, :prod) ||
-                       services.available?(:kubernetes_ng, :canary) 
+                       # prod/canary with persephone tag OR in qa-de-1
+                       ((services.available?(:kubernetes_ng, :prod) || services.available?(:kubernetes_ng, :canary)) &&
+                         (current_region == "qa-de-1" || @active_project&.tags&.include?('persephone'))) ||
+                       # qa in qa-de-1 region
+                       (services.available?(:kubernetes_ng, :qa) && current_region == "qa-de-1")
                      ))
                    } do |containers_nav|
       containers_nav.item :kubernetes,
@@ -139,47 +142,31 @@ SimpleNavigation::Configuration.run do |navigation|
                             },
                           highlights_on:
                             proc { params[:controller][%r{kubernetes/.*}] }
-      containers_nav.item :kubernetes_ng_prod,
-                          capture {
-                            concat 'Kubernetes '
-                            concat content_tag(
-                              :span, 'gardener', class: 'label label-info'
-                            )
-                          },
-                            -> { plugin('kubernetes_ng').service_path(landscape_name: 'prod') },
-                            if:
-                            lambda {
-                              plugin_available?(:kubernetes_ng) && services.available?(:kubernetes_ng, :prod) && (current_region == "qa-de-1" || (@active_project&.tags && @active_project.tags.include?('persephone'))) },
-                          highlights_on:
-                            proc { params[:controller][%r{kubernetes_ng/.*}] && request.path.include?('/prod') }
 
-      containers_nav.item :kubernetes_ng_canary,
-                          capture {
-                            concat 'Kubernetes Canary '
-                            concat content_tag(
-                              :span, 'gardener', class: 'label label-info'
-                            )
-                          },
-                          -> { plugin('kubernetes_ng').service_path(landscape_name: 'canary') },
-                          if:
-                            lambda {
-                              plugin_available?(:kubernetes_ng) && services.available?(:kubernetes_ng, :canary) && (current_region == "qa-de-1" || (@active_project&.tags && @active_project.tags.include?('persephone'))) },
-                          highlights_on:
-                            proc { params[:controller][%r{kubernetes_ng/.*}] && request.path.include?('/canary') }
-
-      containers_nav.item :kubernetes_ng_qa,
-                          capture {
-                            concat 'Kubernetes QA '
-                            concat content_tag(
-                              :span, 'gardener', class: 'label label-info'
-                            )
-                          },
-                          -> { plugin('kubernetes_ng').service_path(landscape_name: 'qa') },
-                          if:
-                            lambda {
-                              plugin_available?(:kubernetes_ng) && services.available?(:kubernetes_ng, :qa) && current_region == "qa-de-1" },
-                          highlights_on:
-                            proc { params[:controller][%r{kubernetes_ng/.*}] && request.path.include?('/qa') }
+      # Generate navigation items for each kubernetes_ng landscape
+      KubernetesNg::LANDSCAPES.each do |landscape_name, config|
+        nav_label = config[:nav_label]
+        containers_nav.item :"kubernetes_ng_#{landscape_name}",
+                            capture {
+                              concat "#{nav_label} "
+                              concat content_tag(:span, 'gardener', class: 'label label-info')
+                            },
+                            -> { plugin('kubernetes_ng').service_path(landscape_name: landscape_name) },
+                            if: lambda {
+                              plugin_available?(:kubernetes_ng) &&
+                                services.available?(:kubernetes_ng, landscape_name.to_sym) &&
+                                if config[:user_facing]
+                                  # prod/canary: with persephone tag OR in qa-de-1
+                                  current_region == "qa-de-1" || @active_project&.tags&.include?('persephone')
+                                else
+                                  # qa: only in qa-de-1 region
+                                  current_region == "qa-de-1"
+                                end
+                            },
+                            highlights_on: proc {
+                              params[:controller][%r{kubernetes_ng/.*}] && request.path.include?("/#{landscape_name}")
+                            }
+      end
     end
 
     primary.item :hana,

--- a/plugins/kubernetes_ng/lib/kubernetes_ng.rb
+++ b/plugins/kubernetes_ng/lib/kubernetes_ng.rb
@@ -11,17 +11,20 @@ module KubernetesNg
     'prod' => {
       service: 'persephone-prod',
       display_name: 'Prod',
+      nav_label: 'Kubernetes',
       user_facing: true
     },
     'canary' => {
       service: 'persephone-canary',
       display_name: 'Canary',
+      nav_label: 'Kubernetes Canary',
       user_facing: true
     },
     'qa' => {
       service: 'persephone-qa',
       display_name: 'QA',
-      user_facing: false  # Internal/QA only - not shown error messages
+      nav_label: 'Kubernetes QA',
+      user_facing: false  # Internal/QA only - only visible in qa-de-1 region
     }
   }.freeze
 
@@ -36,6 +39,10 @@ module KubernetesNg
 
   def self.display_name_for(landscape_name)
     LANDSCAPES.dig(landscape_name, :display_name) || landscape_name.capitalize
+  end
+
+  def self.nav_label_for(landscape_name)
+    LANDSCAPES.dig(landscape_name, :nav_label)
   end
 
   # Landscapes shown in error messages


### PR DESCRIPTION
# Summary

This PR centralizes the landscape configuration in `KubernetesNg::LANDSCAPES` to eliminate hardcoded duplications across the codebase. The navigation now dynamically generates menu items by iterating over the central config, using a new `nav_label` field for display names. Visibility logic is simplified using the `user_facing` flag: prod and canary are visible in qa-de-1 region or with the persephone project tag, while qa is only visible in qa-de-1. Adding a new landscape now only requires updating `lib/kubernetes_ng.rb`.

# Changes Made

  - **lib/kubernetes_ng.rb**: Added `nav_label` field and `nav_label_for` helper method to central LANDSCAPES config
  - **services_navigation.rb**: Replaced hardcoded navigation items with dynamic loop over `KubernetesNg::LANDSCAPES`

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- #1818

# Screenshots (if applicable)

<!-- If there are any visual changes, provide screenshots or GIFs. -->

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
