### PR TITLE
fix(kubernetes): improve cluster wizard stability and React Query v5 readiness

### DIFF
--- a/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/ClusterWizard/WizzardProvider.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/ClusterWizard/WizzardProvider.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode, useCallback, useMemo, useRef } from "react"
+import React, { createContext, useContext, useState, ReactNode, useCallback, useMemo, useRef, useEffect } from "react"
 import { ClusterFormData, WorkerGroups, WorkerGroup, Step, StepId, ClusterFormErrorsFlat } from "./types"
 import { STEP_DEFINITIONS, DEFAULT_CLOUD_PROFILE_NAME } from "./constants"
 import { GardenerApi } from "../../../../apiClient"
@@ -174,31 +174,38 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ client, region, 
   const clusterFormDataRef = useRef(clusterFormData)
   clusterFormDataRef.current = clusterFormData
 
-  // updates cloud profile, resets dependent fields
-  const updateCloudProfile = (prev: ClusterFormData, newName: string, profiles: CloudProfile[]): ClusterFormData => {
-    const profile = profiles.find((p) => p.name === newName)
-    const latestK8sVersion = profile ? getLatestVersion(profile.kubernetesVersions) : ""
-    const apiVersion = profile ? profile.providerConfig.apiVersion : ""
+  // Track if defaults have been set to prevent re-setting on data changes
+  const cloudProfileDefaultSet = useRef(false)
+  const networkDefaultSet = useRef(false)
 
-    return {
-      ...prev,
-      cloudProfileName: newName,
-      kubernetesVersion: latestK8sVersion,
-      infrastructure: {
-        ...prev.infrastructure,
-        apiVersion: apiVersion,
-      },
-      workers: prev.workers.map((wg) => ({
-        ...wg,
-        machineType: "",
-        machineImage: {
-          name: "",
-          version: "",
+  // updates cloud profile, resets dependent fields
+  const updateCloudProfile = useCallback(
+    (prev: ClusterFormData, newName: string, profiles: CloudProfile[]): ClusterFormData => {
+      const profile = profiles.find((p) => p.name === newName)
+      const latestK8sVersion = profile ? getLatestVersion(profile.kubernetesVersions) : ""
+      const apiVersion = profile ? profile.providerConfig.apiVersion : ""
+
+      return {
+        ...prev,
+        cloudProfileName: newName,
+        kubernetesVersion: latestK8sVersion,
+        infrastructure: {
+          ...prev.infrastructure,
+          apiVersion: apiVersion,
         },
-        zones: [],
-      })),
-    }
-  }
+        workers: prev.workers.map((wg) => ({
+          ...wg,
+          machineType: "",
+          machineImage: {
+            name: "",
+            version: "",
+          },
+          zones: [],
+        })),
+      }
+    },
+    []
+  )
 
   const cloudProfiles = useQuery({
     queryKey: ["cloudProfiles"],
@@ -207,15 +214,6 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ client, region, 
     select: (profiles) => [...profiles].sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 0,
     cacheTime: 0,
-    onSuccess: (profiles) => {
-      setClusterFormData((prev) => {
-        // don’t override if user selected something
-        if (prev.cloudProfileName) return prev
-        // check if default cloud profile exists or take the first one
-        const defaultCloudProfile = profiles.find((p) => p.name === DEFAULT_CLOUD_PROFILE_NAME) ?? profiles[0]
-        return updateCloudProfile(prev, defaultCloudProfile?.name, profiles)
-      })
-    },
   })
 
   const extNetworks = useQuery({
@@ -224,21 +222,45 @@ export const WizardProvider: React.FC<WizardProviderProps> = ({ client, region, 
     enabled: !!client.gardener.getExternalNetworks,
     staleTime: 0,
     cacheTime: 0,
-    onSuccess: (networks) => {
-      setClusterFormData((prev) => {
-        // don’t override if user selected something
-        if (prev.infrastructure.floatingPoolName) return prev
-        // set the first as default
-        return {
-          ...prev,
-          infrastructure: {
-            ...prev.infrastructure,
-            floatingPoolName: networks[0]?.name || "",
-          },
-        }
-      })
-    },
   })
+
+  // Set cloud profile default as soon as data is available
+  useEffect(() => {
+    if (!cloudProfiles.data || cloudProfileDefaultSet.current) return
+
+    setClusterFormData((prev) => {
+      if (prev.cloudProfileName) {
+        cloudProfileDefaultSet.current = true
+        return prev
+      }
+
+      const defaultProfile =
+        cloudProfiles.data.find((p) => p.name === DEFAULT_CLOUD_PROFILE_NAME) ?? cloudProfiles.data[0]
+      cloudProfileDefaultSet.current = true
+      return updateCloudProfile(prev, defaultProfile?.name, cloudProfiles.data)
+    })
+  }, [cloudProfiles.data, updateCloudProfile])
+
+  // Set network default as soon as data is available
+  useEffect(() => {
+    if (!extNetworks.data || networkDefaultSet.current) return
+
+    setClusterFormData((prev) => {
+      if (prev.infrastructure.floatingPoolName) {
+        networkDefaultSet.current = true
+        return prev
+      }
+
+      networkDefaultSet.current = true
+      return {
+        ...prev,
+        infrastructure: {
+          ...prev.infrastructure,
+          floatingPoolName: extNetworks.data[0]?.name || "",
+        },
+      }
+    })
+  }, [extNetworks.data])
 
   const createMutation = useMutation({
     mutationFn: client.gardener.createCluster,


### PR DESCRIPTION
# Summary

Fix several issues in the cluster wizard: prevent crash when cloud profile has no Kubernetes versions, disable query caching to ensure fresh default values on each wizard open, improve CIDR validation to properly reject invalid IP addresses and subnet masks. Additionally, refactor code for better readability by moving function definitions before usage, optimize performance by using refs and useCallback to prevent unnecessary callback recreation, and replace deprecated onSuccess callbacks with useEffect hooks to prepare for React Query v5 upgrade.

  ## Changes
  - Fix `getLatestVersion` crash on empty arrays
  - Disable React Query caching to prevent stale defaults
  - Improve CIDR validation to check octets (0-255) and mask (0-32)
  - Move `updateCloudProfile` definition before usage
  - Optimize callbacks with `useCallback` and refs
  - Replace deprecated `onSuccess` with `useEffect` for React Query v5

# Related Issues

- #1936 

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
