### PR TITLE
fix(deps): upgrade lodash for security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,7 @@ gem 'unf', '>= 0.2.0beta2'
 
 gem 'jsbundling-rails'
 # https://rubygems.org/gems/rails/versions
-# Upgraded to 7.2.3.1 for Active Storage security fix (Path Traversal CVE)
-gem 'rails', '7.2.3.1'
+gem 'rails', '7.1.6'
 # Security fixes for Rack CVEs (multipart parsing, DoS, file exposure)
 gem 'rack', '>= 3.2.6'
 # Security fix for rack-session CVE (session forgery and Marshal deserialization)

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ gem 'unf', '>= 0.2.0beta2'
 
 gem 'jsbundling-rails'
 # https://rubygems.org/gems/rails/versions
-gem 'rails', '7.1.6'
+# Upgraded to 7.2.3.1 for Active Storage security fix (Path Traversal CVE)
+gem 'rails', '7.2.3.1'
 # Security fixes for Rack CVEs (multipart parsing, DoS, file exposure)
 gem 'rack', '>= 3.2.6'
 # Security fix for rack-session CVE (session forgery and Marshal deserialization)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jquery.cookie": "1.4.1",
     "js-base64": "^2.1.8",
     "js-yaml": "^4.1.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "moment": "^2.29.2",
     "numeral": "^2.0.6",
     "prop-types": "^15.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ dependencies:
     specifier: ^4.1.1
     version: 4.1.1
   lodash:
-    specifier: ^4.17.21
-    version: 4.17.23
+    specifier: ^4.18.0
+    version: 4.18.1
   moment:
     specifier: ^2.29.2
     version: 2.30.1
@@ -2756,7 +2756,7 @@ packages:
       '@nivo/core': 0.85.1(react-dom@18.2.0)(react@18.2.0)
       '@react-spring/web': 9.7.5(react-dom@18.2.0)(react@18.2.0)
       '@types/prop-types': 15.7.15
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 18.2.0
     transitivePeerDependencies:
@@ -2799,7 +2799,7 @@ packages:
       '@types/d3-shape': 2.1.7
       d3-scale: 4.0.2
       d3-shape: 1.3.7
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.2.0
     transitivePeerDependencies:
       - react-dom
@@ -2818,7 +2818,7 @@ packages:
       d3-color: 3.1.0
       d3-scale: 4.0.2
       d3-scale-chromatic: 3.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 18.2.0
     transitivePeerDependencies:
@@ -2841,7 +2841,7 @@ packages:
       d3-scale-chromatic: 3.1.0
       d3-shape: 1.3.7
       d3-time-format: 3.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       react: 18.2.0
     transitivePeerDependencies:
@@ -2864,7 +2864,7 @@ packages:
       d3-scale-chromatic: 3.1.0
       d3-shape: 3.2.0
       d3-time-format: 3.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.2.0
       react-virtualized-auto-sizer: 1.0.26(react-dom@18.2.0)(react@18.2.0)
       use-debounce: 10.1.0(react@18.2.0)
@@ -2909,7 +2909,7 @@ packages:
       d3-scale: 4.0.2
       d3-time: 1.1.0
       d3-time-format: 3.0.0
-      lodash: 4.17.23
+      lodash: 4.18.1
     dev: false
 
   /@nivo/theming@0.99.0(react@18.2.0):
@@ -2917,7 +2917,7 @@ packages:
     peerDependencies:
       react: ^16.14 || ^17.0 || ^18.0 || ^19.0
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 18.2.0
     dev: false
 
@@ -5396,7 +5396,7 @@ packages:
       hasha: 5.2.2
       is-installed-globally: 0.4.0
       listr2: 3.14.0(enquirer@2.4.1)
-      lodash: 4.17.23
+      lodash: 4.18.1
       log-symbols: 4.1.0
       minimist: 1.2.8
       ospath: 1.2.2
@@ -7805,8 +7805,8 @@ packages:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
     dev: true
 
-  /lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  /lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -8554,7 +8554,7 @@ packages:
       create-react-context: 0.3.0(prop-types@15.8.1)(react@18.2.0)
       escape-string-regexp: 1.0.5
       invariant: 2.2.4
-      lodash: 4.17.23
+      lodash: 4.18.1
       prop-types: 15.8.1
       prop-types-extra: 1.1.1(react@18.2.0)
       react: 18.2.0


### PR DESCRIPTION
## Summary

Fixes 2 Dependabot security alerts for lodash:

- **#329**: lodash <= 4.17.23 - Multiple vulnerabilities

## Changes

- Upgraded `lodash` from 4.17.21 → 4.18.1
- Direct dependency update in package.json
- All transitive dependencies updated via pnpm-lock.yaml

## Security Impact

Lodash <= 4.17.23 had multiple known vulnerabilities that are fixed in 4.18.0+. This update resolves all lodash-related Dependabot alerts.

## Test Plan

- [ ] Verify application starts successfully
- [ ] Test JavaScript functionality
- [ ] Confirm Dependabot alert #329 is resolved

## Notes

- This is a minor version update (4.17 → 4.18) with minimal breaking changes
- All affected packages using lodash as transitive dependency are also updated