### PR TITLE
fix(kubernetes): filter machine images by region availability

### DIFF
--- a/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_services/cloud_profiles.rb
+++ b/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_services/cloud_profiles.rb
@@ -7,10 +7,6 @@ module ServiceLayer
         response = elektron_gardener.get("apis/core.gardener.cloud/v1beta1/cloudprofiles")
         cloud_profiles = response&.body&.dig("items") || []
 
-        puts "========+++++++========="
-        puts "Raw cloud profiles data: #{cloud_profiles.inspect}"
-        puts "========+++++++========="
-
         cloud_profiles.map do |item|
           next unless item.is_a?(Hash)
 
@@ -113,10 +109,6 @@ module ServiceLayer
       
       def safe_map_machine_images(machine_images, provider_config_machine_images)
         return [] unless machine_images.is_a?(Array)
-
-        puts "========+++++++========="
-        puts "Raw machine images data: #{machine_images.inspect}"
-        puts "========+++++++========="
 
         machine_images.filter_map do |mi|
           next unless mi.is_a?(Hash) && mi['name']

--- a/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_services/cloud_profiles.rb
+++ b/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_services/cloud_profiles.rb
@@ -7,13 +7,20 @@ module ServiceLayer
         response = elektron_gardener.get("apis/core.gardener.cloud/v1beta1/cloudprofiles")
         cloud_profiles = response&.body&.dig("items") || []
 
+        puts "========+++++++========="
+        puts "Raw cloud profiles data: #{cloud_profiles.inspect}"
+        puts "========+++++++========="
+
         cloud_profiles.map do |item|
           next unless item.is_a?(Hash)
-          
+
           metadata = item.dig('metadata') || {}
           spec = item.dig('spec') || {}
           kubernetes = spec.dig('kubernetes') || {}
-          
+
+          # Extract provider config machine images for region filtering
+          provider_config_machine_images = extract_provider_config_machine_images(spec)
+
           {
             uid: metadata['uid'],
             name: metadata['name'],
@@ -21,7 +28,7 @@ module ServiceLayer
             providerConfig: extract_provider_config(spec),
             kubernetesVersions: safe_map_versions(kubernetes['versions']), # Changed from kubernetes_versions
             machineTypes: safe_map_machine_types(spec['machineTypes']), # Changed from machine_types
-            machineImages: safe_map_machine_images(spec['machineImages']), # Changed from machine_images
+            machineImages: safe_map_machine_images(spec['machineImages'], provider_config_machine_images), # Changed from machine_images
             regions: safe_map_regions(spec['regions']),
             volumeTypes: safe_map_volume_types(spec['volumeTypes']) # Changed from volume_types
           }
@@ -29,13 +36,56 @@ module ServiceLayer
       end
       
       private
-      
+
       def extract_provider_config(spec)
         provider_config = spec['providerConfig']
-        return {} unless provider_config.is_a?(Hash) && provider_config['apiVersion']      
+        return {} unless provider_config.is_a?(Hash) && provider_config['apiVersion']
         {
           apiVersion: provider_config['apiVersion']
         }
+      end
+
+      def extract_provider_config_machine_images(spec)
+        provider_config = spec['providerConfig']
+        return {} unless provider_config.is_a?(Hash)
+
+        machine_images = provider_config['machineImages']
+        return {} unless machine_images.is_a?(Array)
+
+        # Build a lookup structure: { image_name => { version => [region_names] } }
+        lookup = {}
+        machine_images.each do |mi|
+          next unless mi.is_a?(Hash) && mi['name']
+
+          image_name = mi['name']
+          lookup[image_name] ||= {}
+
+          versions = mi['versions']
+          next unless versions.is_a?(Array)
+
+          versions.each do |version_info|
+            next unless version_info.is_a?(Hash) && version_info['version']
+
+            version = version_info['version']
+            regions = version_info['regions']
+            next unless regions.is_a?(Array)
+
+            region_names = regions.filter_map { |r| r['name'] if r.is_a?(Hash) }
+            lookup[image_name][version] = region_names
+          end
+        end
+
+        lookup
+      end
+
+      def filter_versions_by_region(image_name, versions, provider_config_lookup, current_region)
+        return versions unless provider_config_lookup[image_name]
+
+        versions.select do |version|
+          region_list = provider_config_lookup.dig(image_name, version)
+          # Include version if it's available in the current region
+          region_list && region_list.include?(current_region)
+        end
       end
 
       def safe_map_versions(versions)
@@ -61,17 +111,30 @@ module ServiceLayer
         end
       end
       
-      def safe_map_machine_images(machine_images)
+      def safe_map_machine_images(machine_images, provider_config_machine_images)
         return [] unless machine_images.is_a?(Array)
-        
+
+        puts "========+++++++========="
+        puts "Raw machine images data: #{machine_images.inspect}"
+        puts "========+++++++========="
+
         machine_images.filter_map do |mi|
           next unless mi.is_a?(Hash) && mi['name']
-          
-          versions = mi['versions'].is_a?(Array) ? mi['versions'].filter_map { |v| v['version'] if v.is_a?(Hash) } : []
-          
+
+          # Extract versions from spec/machineImages
+          spec_versions = mi['versions'].is_a?(Array) ? mi['versions'].filter_map { |v| v['version'] if v.is_a?(Hash) } : []
+
+          # Filter versions by checking availability in providerConfig for the current region
+          available_versions = if region && provider_config_machine_images.is_a?(Hash)
+            filter_versions_by_region(mi['name'], spec_versions, provider_config_machine_images, region)
+          else
+            # If no region configured, return all versions
+            spec_versions
+          end
+
           {
             name: mi['name'],
-            versions: versions
+            versions: available_versions
           }
         end
       end

--- a/plugins/kubernetes_ng/spec/services/service_layer/kubernetes_ng_services/cloud_profiles_spec.rb
+++ b/plugins/kubernetes_ng/spec/services/service_layer/kubernetes_ng_services/cloud_profiles_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe ServiceLayer::KubernetesNgServices::CloudProfiles do
       # Mock the elektron_gardener client
       allow(self).to receive(:elektron_gardener).and_return(double('elektron_gardener'))
       allow(elektron_gardener).to receive(:get).with("apis/core.gardener.cloud/v1beta1/cloudprofiles").and_return(mock_response)
+      # Mock the region method (returns nil by default, no filtering)
+      allow(self).to receive(:region).and_return(nil)
     end
 
     it "returns cloud profiles in camelCase format" do
@@ -117,17 +119,173 @@ RSpec.describe ServiceLayer::KubernetesNgServices::CloudProfiles do
     it "correctly maps machine images with versions" do
       result = list_cloud_profiles
       cloud_profile = result.first
-      
+
       # Test machineImages array structure
       expect(cloud_profile[:machineImages]).to be_an(Array)
       expect(cloud_profile[:machineImages].length).to eq(1)
-      
+
       machine_image = cloud_profile[:machineImages].first
       expect(machine_image).to include(
         name: "flatcar",
         versions: ["1.0.0"]
       )
       expect(machine_image[:versions]).to be_an(Array)
+    end
+
+    context "when filtering machine images by region" do
+      let(:mock_response_with_provider_config) do
+        double('response', body: {
+          "items" => [
+            {
+              "metadata" => {
+                "uid" => "test-uid",
+                "name" => "openstack"
+              },
+              "spec" => {
+                "type" => "openstack",
+                "providerConfig" => {
+                  "apiVersion" => "openstack.provider.extensions.gardener.cloud/v1alpha1",
+                  "machineImages" => [
+                    {
+                      "name" => "gardenlinux",
+                      "versions" => [
+                        {
+                          "version" => "1877.8.0",
+                          "image" => "gardenlinux-1877.8",
+                          "regions" => [
+                            { "name" => "eu-de-1", "id" => "id-1" },
+                            { "name" => "qa-de-1", "id" => "id-2" }
+                          ]
+                        },
+                        {
+                          "version" => "1877.9.0",
+                          "image" => "gardenlinux-1877.9",
+                          "regions" => [
+                            { "name" => "qa-de-1", "id" => "id-3" }
+                          ]
+                        },
+                        {
+                          "version" => "1877.10.0",
+                          "image" => "gardenlinux-1877.10",
+                          "regions" => [
+                            { "name" => "eu-de-1", "id" => "id-4" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "machineImages" => [
+                  {
+                    "name" => "gardenlinux",
+                    "versions" => [
+                      { "version" => "1877.8.0" },
+                      { "version" => "1877.9.0" },
+                      { "version" => "1877.10.0" }
+                    ]
+                  }
+                ],
+                "kubernetes" => { "versions" => [] },
+                "machineTypes" => [],
+                "regions" => [],
+                "volumeTypes" => []
+              }
+            }
+          ]
+        })
+      end
+
+      before do
+        allow(elektron_gardener).to receive(:get).and_return(mock_response_with_provider_config)
+      end
+
+      context "when region is qa-de-1" do
+        before do
+          allow(self).to receive(:region).and_return("qa-de-1")
+        end
+
+        it "filters machine image versions to only show versions available in qa-de-1" do
+          result = list_cloud_profiles
+          cloud_profile = result.first
+
+          machine_image = cloud_profile[:machineImages].first
+          expect(machine_image[:name]).to eq("gardenlinux")
+          expect(machine_image[:versions]).to contain_exactly("1877.8.0", "1877.9.0")
+          expect(machine_image[:versions]).not_to include("1877.10.0")
+        end
+      end
+
+      context "when region is eu-de-1" do
+        before do
+          allow(self).to receive(:region).and_return("eu-de-1")
+        end
+
+        it "filters machine image versions to only show versions available in eu-de-1" do
+          result = list_cloud_profiles
+          cloud_profile = result.first
+
+          machine_image = cloud_profile[:machineImages].first
+          expect(machine_image[:name]).to eq("gardenlinux")
+          expect(machine_image[:versions]).to contain_exactly("1877.8.0", "1877.10.0")
+          expect(machine_image[:versions]).not_to include("1877.9.0")
+        end
+      end
+
+      context "when region is not set" do
+        before do
+          allow(self).to receive(:region).and_return(nil)
+        end
+
+        it "returns all machine image versions without filtering" do
+          result = list_cloud_profiles
+          cloud_profile = result.first
+
+          machine_image = cloud_profile[:machineImages].first
+          expect(machine_image[:name]).to eq("gardenlinux")
+          expect(machine_image[:versions]).to contain_exactly("1877.8.0", "1877.9.0", "1877.10.0")
+        end
+      end
+
+      context "when providerConfig is missing" do
+        let(:mock_response_without_provider_config) do
+          double('response', body: {
+            "items" => [
+              {
+                "metadata" => { "uid" => "test-uid", "name" => "openstack" },
+                "spec" => {
+                  "type" => "openstack",
+                  "machineImages" => [
+                    {
+                      "name" => "gardenlinux",
+                      "versions" => [
+                        { "version" => "1877.8.0" },
+                        { "version" => "1877.9.0" }
+                      ]
+                    }
+                  ],
+                  "kubernetes" => { "versions" => [] },
+                  "machineTypes" => [],
+                  "regions" => [],
+                  "volumeTypes" => []
+                }
+              }
+            ]
+          })
+        end
+
+        before do
+          allow(elektron_gardener).to receive(:get).and_return(mock_response_without_provider_config)
+          allow(self).to receive(:region).and_return("eu-de-1")
+        end
+
+        it "returns all machine image versions without filtering" do
+          result = list_cloud_profiles
+          cloud_profile = result.first
+
+          machine_image = cloud_profile[:machineImages].first
+          expect(machine_image[:versions]).to contain_exactly("1877.8.0", "1877.9.0")
+        end
+      end
     end
 
     it "correctly maps regions with zones" do


### PR DESCRIPTION
# Summary

This PR fixes an issue where all machine image versions were displayed regardless of their availability in the current region. The implementation now filters machine images based on the region where Elektra is running, ensuring users can only select images that are actually available in their region.

# Changes Made

- Added `extract_provider_config_machine_images` method to build a lookup structure from
`spec/providerConfig/machineImages` that maps image names and versions to available regions
- Added `filter_versions_by_region` method to filter machine image versions based on region
availability
- Updated `safe_map_machine_images` to accept provider config machine images and apply
region-based filtering using the existing `region` method
- Modified `list_cloud_profiles` to extract and pass provider config machine images to the
filtering logic
- Added comprehensive test coverage for region filtering scenarios:
  - Filtering for `qa-de-1` region
  - Filtering for `eu-de-1` region
  - Behavior when region is not set (returns all versions)
  - Behavior when `providerConfig` is missing (returns all versions)
- Maintained backward compatibility: if no region is configured or providerConfig is missing, all
versions are returned

# Related Issues

https://convergedcloud.slack.com/archives/C08J0UVH29L/p1775747059206159

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.