### PR TITLE
feat(identity): improve rescope error handling with manual rescoping

### DIFF
--- a/app/controllers/concerns/rescue.rb
+++ b/app/controllers/concerns/rescue.rb
@@ -53,20 +53,12 @@ module Rescue
       # "MonsoonOpenstackAuth::Authentication::NotAuthorized" are rescued directly in rescope_token and handled by
       # "rescue_and_render_exception_page" but I leave it here just in case ;-)
       rescue_from "MonsoonOpenstackAuth::Authentication::NotAuthorized" do |exception|
-        # for project "has no access to project"
-        # check MonsoonOpenstackAuth/Authentication/auth_session.rb
-        if exception.message =~ /has no access to project/
-          # Return 200 OK instead of 401/403 to prevent OAuth redirect loop
-          # User IS authenticated (passed OAuth), just not authorized for this scope
-          # Using 401 would cause OAuth proxy to redirect back to IdP, creating a loop
-          render(template: "application/exceptions/unauthorized")
-        else
-          redirect_to monsoon_openstack_auth.login_path(
-                        domain_fid: @scoped_domain_fid,
-                        domain_name: @scoped_domain_name,
-                        after_login: params[:after_login],
-                      )
-        end
+        # Return 200 OK instead of 401/403 to prevent OAuth redirect loop
+        # User IS authenticated (passed OAuth), just not authorized for this scope
+        # Using 401 would cause OAuth proxy to redirect back to IdP, creating a loop
+        # This rescue_from should rarely be triggered as DashboardController handles
+        # NotAuthorized more specifically in rescope_token_with_error_handling
+        render(template: "application/exceptions/unauthorized")
       end
 
       # handle all api errors

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,8 +8,12 @@ class DashboardController < ::ScopeController
     domain: lambda { |c| c.instance_variable_get(:@scoped_domain_id)},
     domain_name: lambda { |c| c.instance_variable_get(:@scoped_domain_name)},
     project: lambda { |c| c.instance_variable_get(:@scoped_project_id)},
-    two_factor: :two_factor_required?
+    two_factor: :two_factor_required?,
+    rescope: false  # Don't rescope automatically - we'll do it manually to handle errors gracefully
   )
+
+  # Manual rescoping with error handling to prevent OAuth redirect loop
+  before_action :rescope_token_with_error_handling
 
   before_action { params.delete(:after_login) }                    
   before_action :check_terms_of_use, except: %i[accept_terms_of_use terms_of_use]
@@ -22,28 +26,6 @@ class DashboardController < ::ScopeController
   rescue_from MonsoonOpenstackAuth::Authentication::NotAuthenticated do |exception|
     # User is not logged in - return 401 to trigger OAuth login
     render template: 'application/exceptions/not_authenticated', status: :unauthorized
-  end
-
-  # Handle case when user is authenticated but not authorized for the scope
-  rescue_from MonsoonOpenstackAuth::Authentication::NotAuthorized do |exception|
-    if @scoped_project_id
-      # User tried to access a project
-      project = FriendlyIdEntry.find_project(@scoped_domain_id, @scoped_project_id)
-      if project.nil?
-        # Project doesn't exist
-        render template: 'application/exceptions/project_not_found', status: :not_found
-      else
-        # Project exists but user has no permission
-        # Use 200 OK to prevent OAuth redirect loop (user IS authenticated)
-        render template: 'application/exceptions/unauthorized', status: :ok
-      end
-    else
-      # User tried to access domain-scoped page (e.g., /monsoon3/home)
-      # This is OK - the user can still see /monsoon3/auth/projects
-      # Don't render anything, just ignore the exception and let the request continue
-      # The rescope failed but user is authenticated and can access domain-level pages
-      nil
-    end
   end
 
   def check_terms_of_use
@@ -95,7 +77,33 @@ class DashboardController < ::ScopeController
     render action: :terms_of_use
   end
 
-  private 
+  private
+
+  def rescope_token_with_error_handling
+    begin
+      # Try to rescope token to domain/project using the authentication instance method
+      authentication_rescope_token
+    rescue MonsoonOpenstackAuth::Authentication::NotAuthorized => e
+      # Rescoping failed - user doesn't have permissions for this scope
+      if @scoped_project_id
+        # User tried to access a project
+        project = FriendlyIdEntry.find_project(@scoped_domain_id, @scoped_project_id)
+        if project.nil?
+          # Project doesn't exist
+          render template: 'application/exceptions/project_not_found', status: :not_found
+        else
+          # Project exists but user has no permission
+          # Use 200 OK to prevent OAuth redirect loop (user IS authenticated)
+          render template: 'application/exceptions/unauthorized', status: :ok
+        end
+      else
+        # Domain-scoped without project: user can still access certain pages
+        # like /monsoon3/auth/projects even without domain permissions
+        # Don't render - just log and continue, allowing the controller action to execute
+        Rails.logger.info "Rescope failed for domain #{@scoped_domain_id}: #{e.message}. Continuing without rescope."
+      end
+    end
+  end
 
   def project_id_required
     return unless params[:project_id].blank?


### PR DESCRIPTION
## Overview

This PR improves upon #2006 by refactoring how we handle rescoping errors. Instead of relying on `rescue_from` blocks, we now handle rescope failures directly in a `before_action` callback, giving us better control over the error handling flow.

## Problem with Previous Approach

In #2006, we used `rescue_from MonsoonOpenstackAuth::Authentication::NotAuthorized` to catch rescope failures. However, this approach had limitations:

- The exception was caught **after** it was raised, interrupting the normal request flow
- For domain-scoped requests, we couldn't easily continue to the controller action
- Returning `nil` from the rescue block caused blank pages
- Error handling logic was split between the rescue block and the actual rescoping

## Solution

### Manual Rescoping with Error Handling

```ruby
authentication_required(
  # ... other options ...
  rescope: false  # Disable automatic rescoping
)

before_action :rescope_token_with_error_handling
```

The new `rescope_token_with_error_handling` method:
1. Calls `authentication_rescope_token` manually
2. Catches `NotAuthorized` exceptions inline
3. Handles errors based on scope type:
   - **Project-scoped**: Renders unauthorized/not_found with HTTP 200
   - **Domain-scoped**: Logs and continues (allows action to execute)

### Simplified Rescue Concern

Also cleaned up `app/controllers/concerns/rescue.rb`:
- Removed the `else` branch that redirected to login
- Now always renders unauthorized template with HTTP 200
- Simpler, more consistent error handling

## Benefits

✅ **No more blank pages** - domain-scoped requests continue normally  
✅ **Cleaner error handling** - errors caught where they occur  
✅ **Better control** - can decide per-scope how to handle failures  
✅ **Prevents OAuth loops** - HTTP 200 for authorization failures  
✅ **Maintains #2006 fixes** - all previous improvements still work  

## Testing

All 342 tests passing:
```bash
docker exec elektra-dev bundle exec rspec spec/controllers/dashboard_controller_spec.rb plugins/monsoon-openstack-auth/spec/
```

## Changes

- `app/controllers/dashboard_controller.rb`: Added manual rescoping with `rescope: false` and `rescope_token_with_error_handling`
- `app/controllers/concerns/rescue.rb`: Simplified NotAuthorized handling

## Related

- Builds on #2006 (OAuth redirect loop fix)