### PR TITLE
fix(networking): resolve BGP VPN project link redirect to SAP SSO

### DIFF
--- a/plugins/networking/app/controllers/networking/bgp_vpns_controller.rb
+++ b/plugins/networking/app/controllers/networking/bgp_vpns_controller.rb
@@ -17,6 +17,22 @@ module Networking
       if code.to_i >= 400
         render json: { errors: bgp_vpns }, status: code
       else
+        # extend items with domain id, needed for url generation
+        projectsCache = {}
+        if @active_project 
+          projectsCache[@active_project.id] = @active_project
+        end
+
+        bgp_vpns["bgpvpns"].each do |item|
+          
+          if projectsCache.key?(item["project_id"])
+            item["domain_id"] = projectsCache[item["project_id"]].domain_name
+          else
+            project = services.identity.find_project(item["project_id"])
+            projectsCache[item["project_id"]] = project if project    
+            item["domain_id"] = project.domain_id if project
+          end
+        end
         render json: bgp_vpns
       end
     end
@@ -25,8 +41,12 @@ module Networking
       code, bgp_vpn = services.networking.create_bgp_vpn(params.require(:name))
 
       if code.to_i >= 400
-        render json: { errors: bgp_vpn }, status: code
+        render json: { errors: bgp_vpn.body }, status: code
       else
+        bgp_vpn = bgp_vpn.body
+        # extend items with domain id, needed for url generation
+        project = services.identity.find_project(bgp_vpn["bgpvpn"]["project_id"])
+        bgp_vpn["bgpvpn"]["domain_id"] = project.domain_id if project
         render json: bgp_vpn
       end
     end

--- a/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/list.jsx
+++ b/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/list.jsx
@@ -92,6 +92,8 @@ const BgpVpns = () => {
     )
   }, [bgpvpns.items, filter])
 
+  console.log("============================",filteredItems)
+
   return (
     <>
       <div className="toolbar">
@@ -142,8 +144,9 @@ const BgpVpns = () => {
                 <td>
                   {cachedProjectsData[item.project_id] ? (
                     <>
+                    
                       <a
-                        href={`/_/${item.project_id}`}
+                        href={`/${item.domain_id}/${item.project_id}`}
                         target="_blank"
                         rel="noreferrer"
                       >

--- a/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/list.jsx
+++ b/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/list.jsx
@@ -92,8 +92,6 @@ const BgpVpns = () => {
     )
   }, [bgpvpns.items, filter])
 
-  console.log("============================",filteredItems)
-
   return (
     <>
       <div className="toolbar">

--- a/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/new.jsx
+++ b/plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/new.jsx
@@ -36,7 +36,7 @@ const New = () => {
       return apiClient
         .post("../../bgp-vpns", { name: values.name })
         .then((data) => {
-          dispatch("bgpvpns", "add", { name: "items", item: data.body.bgpvpn })
+          dispatch("bgpvpns", "add", { name: "items", item: data.bgpvpn })
           close()
         })
         .catch((error) => {


### PR DESCRIPTION
## Summary

Fixes project links in the BGP VPN tab that were incorrectly redirecting to SAP SSO instead of navigating to the target project in Elektra.

## Problem

In Sovereign Cloud DEV/PRD iaas-domains, clicking on project links from the BGP VPN list redirected users to SAP SSO (`auth.eu-de-1.cloud.sap/oauth2/start?...`) instead of opening the target project context in Elektra.

**Affected domains:**
- `iaas-*` 

## Root Cause

The project links used the short-link format `/_/{project_id}`, which does not resolve correctly in iaas-domains. The correct format requires both domain_id and project_id: `/{domain_id}/{project_id}`.

## Solution

- **Backend (controller):** Extend BGP VPN items with `domain_id` by fetching project details from the identity service. Implemented project caching to minimize repeated API calls.
- **Frontend (list component):** Update project link format from `/_/{project_id}` to `/{domain_id}/{project_id}`.
- **Bug fix:** Corrected response handling in the create action to properly extract nested data structure.

## Changes

- `plugins/networking/app/controllers/networking/bgp_vpns_controller.rb`: Add domain_id enrichment logic with caching
- `plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/list.jsx`: Update link format
- `plugins/networking/app/javascript/widgets/bgp_vpns/components/bgp_vpns/new.jsx`: Fix response body handling
