### PR TITLE
feat(thalamus): add Thalamus inference service plugin (qa-de-1/cc-demo only)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,11 @@ PATH
     testikus (0.0.1)
 
 PATH
+  remote: plugins/thalamus
+  specs:
+    thalamus (0.0.1)
+
+PATH
   remote: plugins/tools
   specs:
     tools (0.0.1)
@@ -689,6 +694,7 @@ DEPENDENCIES
   spinners
   spring
   testikus!
+  thalamus!
   tools!
   unf (>= 0.2.0beta2)
   web-console

--- a/app/assets/stylesheets/_monsoon_theme.scss
+++ b/app/assets/stylesheets/_monsoon_theme.scss
@@ -600,6 +600,12 @@ section {
   @extend .fa-area-chart;
 }
 
+.ai-platform-icon {
+  @extend .fa;
+  @extend .fa-fw;
+  @extend .fa-microchip;
+}
+
 .project-icon {
   @extend .fa;
   @extend .fa-fw;

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -39,6 +39,7 @@ export const scopes = [
   "tools",
   "webconsole",
   "smartops",
+  "thalamus",
   "cypress",
   "deps",
   "docker",

--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -516,11 +516,35 @@ SimpleNavigation::Configuration.run do |navigation|
                             plugin('smartops').start_path
                           },
                           if: lambda {
-                            services.available?(:smartops) 
+                            services.available?(:smartops)
                           },
                           highlights_on: lambda {
                               params[:controller][%r{smartops/.*}]
                             }
+    end
+
+    primary.item :ai_platform,
+                 'AI Platform',
+                 nil,
+                 html: {
+                   class: 'fancy-nav-header',
+                   "data-icon": 'ai-platform-icon'
+                 },
+                 if: lambda {
+                   plugin_available?(:thalamus) &&
+                     current_region == "qa-de-1" &&
+                     @active_project&.name == "cc-demo"
+                 } do |ai_nav|
+      ai_nav.item :thalamus,
+                  'Inference Service',
+                  -> { plugin('thalamus').root_path },
+                  if: lambda {
+                    current_region == "qa-de-1" &&
+                      @active_project&.name == "cc-demo"
+                  },
+                  highlights_on: lambda {
+                    params[:controller][%r{thalamus/.*}]
+                  }
     end
 
     primary.item :cc_tools,

--- a/plugins/thalamus/README.md
+++ b/plugins/thalamus/README.md
@@ -1,0 +1,28 @@
+# Thalamus
+Short description and motivation.
+
+## Usage
+How to use my plugin.
+
+## Installation
+Add this line to your application's Gemfile:
+
+```ruby
+gem "thalamus"
+```
+
+And then execute:
+```bash
+$ bundle
+```
+
+Or install it yourself as:
+```bash
+$ gem install thalamus
+```
+
+## Contributing
+Contribution directions go here.
+
+## License
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/plugins/thalamus/Rakefile
+++ b/plugins/thalamus/Rakefile
@@ -1,0 +1,5 @@
+require "bundler/setup"
+
+load "rails/tasks/statistics.rake"
+
+require "bundler/gem_tasks"

--- a/plugins/thalamus/app/assets/stylesheets/thalamus/_application.scss
+++ b/plugins/thalamus/app/assets/stylesheets/thalamus/_application.scss
@@ -1,0 +1,22 @@
+/****************************************************
+  We are using SASS!
+  DO NOT USE require, require_tree, and require_self.
+  ***************************************************
+
+  Instead require further sass files by calling the "@import" directive.
+  e.g. @import "mixins";
+  FYI:
+  The core app automatically namespaces a plugin's css with the plugin name. I.e. it encapsulates a plugin's css in a class with the same name as plugin (e.g. a plugin with name "myplugin" gets surrounded with css class ".myplugin").
+  This means that in the compiled css e.g. .test { color: #f00; } becomes .myplugin .test { color: #f00; }
+  The core app also ensures that the content div surrounding the plugin views gets a css class with the name of current plugin.
+  This way we ensure that your styles take effect only inside the content of your plugin and don't accidentally overwrite styles defined elsewhere (either in the core or in another plugin).
+
+  ***************************************************
+  IMPORTANT
+  ---------------------------------------------------
+  1) The namespacing happens automatically. There is no special action required from the plugin author. The only thing you need to pay attention to is that you write styles only for elements in the context of your plugin's views.
+
+  2) Make sure all your scss files are partials (i.e. the file name starts with an underscore, e.g. "_application.scss"). Otherwise the base imports in the main stylesheet won't be available in your engine stylesheets!
+  ***************************************************
+
+*/

--- a/plugins/thalamus/app/controllers/thalamus/application_controller.rb
+++ b/plugins/thalamus/app/controllers/thalamus/application_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Thalamus
+  class ApplicationController < DashboardController
+    def index
+    end
+  end
+end

--- a/plugins/thalamus/app/helpers/thalamus/application_helper.rb
+++ b/plugins/thalamus/app/helpers/thalamus/application_helper.rb
@@ -1,0 +1,4 @@
+module Thalamus
+  module ApplicationHelper
+  end
+end

--- a/plugins/thalamus/app/views/thalamus/application/index.html.haml
+++ b/plugins/thalamus/app/views/thalamus/application/index.html.haml
@@ -1,0 +1,21 @@
+.bs-callout.bs-callout-warning
+  %h4 Proof of Concept
+  %p
+    This service is a <strong>PoC</strong> and is not production-ready.
+    Features may be missing, unstable, or change without notice.
+    Do not use for critical workloads.
+
+%h3 API Access
+%p
+  Thalamus exposes an <strong>OpenAI-compatible API</strong>.
+  You can point any OpenAI SDK or tool (e.g. OpenCode, Open WebUI) at the endpoint below.
+.well
+  %strong API Endpoint:
+  %code http://api.thalamus.eu-de-2.cloud.sap/v1
+
+%h3 Web Frontend
+%p
+  A browser-based chat interface is available for direct interactive use.
+.well
+  %strong Frontend URL:
+  %a{ href: 'http://thalamus.eu-de-2.cloud.sap', target: '_blank' } http://thalamus.eu-de-2.cloud.sap

--- a/plugins/thalamus/bin/rails
+++ b/plugins/thalamus/bin/rails
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path("..", __dir__)
+ENGINE_PATH = File.expand_path("../lib/thalamus/engine", __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_mailbox/engine"
+require "action_text/engine"
+require "action_view/railtie"
+require "action_cable/engine"
+# require "rails/test_unit/railtie"
+require "rails/engine/commands"

--- a/plugins/thalamus/config/policy.json
+++ b/plugins/thalamus/config/policy.json
@@ -1,0 +1,3 @@
+{
+  "thalamus:index": "@"
+}

--- a/plugins/thalamus/config/routes.rb
+++ b/plugins/thalamus/config/routes.rb
@@ -1,0 +1,1 @@
+Thalamus::Engine.routes.draw { get "/" => "application#index", :as => :root }

--- a/plugins/thalamus/lib/tasks/thalamus_tasks.rake
+++ b/plugins/thalamus/lib/tasks/thalamus_tasks.rake
@@ -1,0 +1,4 @@
+# desc "Explaining what the task does"
+# task :thalamus do
+#   # Task goes here
+# end

--- a/plugins/thalamus/lib/thalamus.rb
+++ b/plugins/thalamus/lib/thalamus.rb
@@ -1,0 +1,5 @@
+require "thalamus/engine"
+
+module Thalamus
+  # Your code goes here...
+end

--- a/plugins/thalamus/lib/thalamus/engine.rb
+++ b/plugins/thalamus/lib/thalamus/engine.rb
@@ -1,0 +1,5 @@
+module Thalamus
+  class Engine < ::Rails::Engine
+    isolate_namespace Thalamus
+  end
+end

--- a/plugins/thalamus/spec/controllers/application_controller_spec.rb
+++ b/plugins/thalamus/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Thalamus::ApplicationController, type: :controller do
+  routes { Thalamus::Engine.routes }
+
+  default_params = {
+    domain_id: AuthenticationStub.domain_id,
+    project_id: AuthenticationStub.project_id,
+  }
+
+  before(:all) do
+    FriendlyIdEntry.find_or_create_entry(
+      "Domain",
+      nil,
+      default_params[:domain_id],
+      "default",
+    )
+    FriendlyIdEntry.find_or_create_entry(
+      "Project",
+      default_params[:domain_id],
+      default_params[:project_id],
+      default_params[:project_id],
+    )
+  end
+
+  before :each do
+    stub_authentication
+  end
+
+  describe "GET index" do
+    it "returns http success" do
+      get :index, params: default_params
+      expect(response).to be_successful
+    end
+  end
+end

--- a/plugins/thalamus/thalamus.gemspec
+++ b/plugins/thalamus/thalamus.gemspec
@@ -1,0 +1,10 @@
+$:.push File.expand_path("../lib", __FILE__)
+Gem::Specification.new do |spec|
+  spec.name        = "thalamus"
+  spec.version     = "0.0.1"
+  spec.authors     = ["Elektra UI team"]
+  spec.summary     = "An Elektra plugin"
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  end
+  end


### PR DESCRIPTION
# Summary

This PR adds a new entry in qa-de-1/cc-demo for a new inference service called Thalamus. The view will be used for the demo of the PoC phase and is deliberately kept minimal.

# Changes Made

- Add new plugin using `bin/generate thalamus`
- For cc-demo project in qa-de-1 only: add new navigation entries "AI Platform" -> "Inference Service"

# Related Issues

- None

# Screenshots

<img width="1191" height="819" alt="Screenshot 2026-05-22 at 10 37 57" src="https://github.com/user-attachments/assets/73cb8ebb-2e74-479d-bec7-344f473a1ffe" />
<img width="1203" height="626" alt="Screenshot 2026-05-22 at 10 50 34" src="https://github.com/user-attachments/assets/23d97c7d-6838-43f2-a9ce-18370a26a3a6" />

# Checklist

- [x] I have performed a self-review of my code.