### PR TITLE
fix(kubernetes): prevent wizard refetch on window focus

### DIFF
--- a/plugins/kubernetes_ng/app/javascript/widgets/app/hooks/useCloudProfileQueries.ts
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/hooks/useCloudProfileQueries.ts
@@ -16,6 +16,7 @@ export function useCloudProfilesQuery(apiClient: GardenerApi, enabled = true) {
     select: (profiles) => [...profiles].sort((a, b) => a.name.localeCompare(b.name)),
     staleTime: 0,
     cacheTime: 0,
+    refetchOnWindowFocus: false,
   })
 }
 

--- a/plugins/kubernetes_ng/app/javascript/widgets/app/hooks/useExternalNetworkQueries.ts
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/hooks/useExternalNetworkQueries.ts
@@ -14,5 +14,6 @@ export function useExternalNetworksQuery(apiClient: GardenerApi, enabled = true)
     enabled: enabled,
     staleTime: 0,
     cacheTime: 0,
+    refetchOnWindowFocus: false,
   })
 }


### PR DESCRIPTION
# Summary

  Fixes an issue where the cluster creation wizard unnecessarily refetches cloud profiles and external networks when the browser window regains focus (e.g., switching tabs or windows),  causing the Next button to become temporarily unavailable and degrading the user experience.

  # Changes Made

  - Added `refetchOnWindowFocus: false` to `useCloudProfilesQuery` hook
  - Added `refetchOnWindowFocus: false` to `useExternalNetworksQuery` hook

  # Related Issues

  N/A

  # Screenshots (if applicable)

  N/A - UX improvement, Next button no longer becomes unavailable when switching tabs

  # Checklist

  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have added tests that prove my fix is effective or that my feature works.
  - [x] New and existing unit tests pass locally with my changes.
  - [ ] I have made corresponding changes to the documentation (if applicable).
  - [x] My changes generate no new warnings or errors.