### PR TITLE
chore(core): use environment variable for db names

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,7 +25,7 @@ development:
   host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_HOST'] || ENV['POSTGRES_ELEKTRA_SERVICE_HOST'] || ENV['POSTGRES_SERVICE_HOST'] || 'localhost' %>
   port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_PORT'] || ENV['POSTGRES_ELEKTRA_SERVICE_PORT'] || ENV['POSTGRES_SERVICE_PORT'] || 5432 %>
 
-  database: monsoon-dashboard_development
+  database: <%= ENV['MONSOON_DB_NAME'] || 'monsoon-dashboard_development' %>
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -68,7 +68,7 @@ test:
   host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_HOST'] || ENV['POSTGRES_ELEKTRA_SERVICE_HOST'] || ENV['POSTGRES_SERVICE_HOST'] || 'localhost' %>
   port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_PORT'] || ENV['POSTGRES_ELEKTRA_SERVICE_PORT'] || ENV['POSTGRES_SERVICE_PORT'] || 5432 %>
 
-  database: monsoon-dashboard_test
+  database: <%= ENV['MONSOON_DB_NAME'] || 'monsoon-dashboard_test' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -100,4 +100,4 @@ production:
   host: <%= ENV['POSTGRES_PORT_5432_TCP_ADDR'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_HOST'] || ENV['POSTGRES_ELEKTRA_SERVICE_HOST'] || ENV['POSTGRES_SERVICE_HOST'] || 'localhost' %>
   port: <%= ENV['POSTGRES_PORT_5432_TCP_PORT'] || ENV['ELEKTRA_POSTGRESQL_SERVICE_PORT'] || ENV['POSTGRES_ELEKTRA_SERVICE_PORT'] || ENV['POSTGRES_SERVICE_PORT'] || 5432 %>
 
-  database: monsoon-dashboard_production
+  database: <%= ENV['MONSOON_DB_NAME'] || 'monsoon-dashboard_production' %>


### PR DESCRIPTION
# Summary

  Add configurable database name via environment variable to support postgresql-ng 2.x compatibility.

  # Changes Made

  - Modified `config/database.yml` to read database name from `MONSOON_DB_NAME` environment variable
  - Added fallback to existing default names for backward compatibility:
    - Development: `monsoon-dashboard_development`
    - Test: `monsoon-dashboard_test`
    - Production: `monsoon-dashboard_production`

  # Problem

  Elektra's database name was hardcoded to `monsoon-dashboard_production` (with underscore), which conflicts with postgresql-ng 2.x constraints:
  - Database names cannot contain underscores in postgresql-ng 2.x
  - User name must match database name in postgresql-ng 2.x

  This prevented deployment in new regions using postgresql-ng 2.x.

  # Solution

  Allow database name to be configured via `MONSOON_DB_NAME` environment variable, enabling use of underscore-free names (e.g., `elektra`) while maintaining backward compatibility for existing deployments.

  # Related Issues

  - Resolves postgresql-ng 2.x compatibility issue for new region deployments

 ## Note: 

I used for consistents the `MONOON_X` name pattern but we should consider to rename the old legacy `MONOON_X` vars to be more generic, but this is a different topic

  # Checklist

  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [x] My changes generate no new warnings or errors.
  - [x] Changes are backward compatible (existing deployments unaffected).  
