### PR TITLE
chore(kubernetes): update scikube setup instructions in cluster view

### DIFF
--- a/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.test.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.test.tsx
@@ -21,6 +21,6 @@ describe("HeadingInfo", () => {
 
     expect(button).toHaveAttribute("aria-expanded", "true")
     expect(screen.getByText(/hide kubectl setup instructions/i)).toBeInTheDocument()
-    expect(screen.getByText(/For conveniently managing your clusters with kubectl/i)).toBeInTheDocument()
+    expect(screen.getByText(/For managing your clusters with kubectl/i)).toBeInTheDocument()
   })
 })

--- a/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
@@ -40,14 +40,12 @@ export default function HeadingInfo() {
 brew tap sap-cloud-infrastructure/tap
 brew install scikube`}
           />
-          <p className="tw-my-4">
-            Then source your OpenStack credentials and generate a garden kubeconfig:
-          </p>
+          <p className="tw-my-4">Then source your OpenStack credentials and generate a garden kubeconfig:</p>
 
           <CodeBlock
             content={`source "<your-openstack-rc-file.sh>"
 # Create garden kubeconfig
-scikube kubeconfig-for-garden --landscape prod > kubeconfig-for-garden.yaml
+scikube kubeconfig-for-garden --landscape <landscape> > kubeconfig-for-garden.yaml
 # List clusters in your project
 KUBECONFIG=kubeconfig-for-garden.yaml kubectl get shoot
 # Connect to a cluster

--- a/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
+++ b/plugins/kubernetes_ng/app/javascript/widgets/app/routes/clusters/-components/HeadingInfo.tsx
@@ -22,41 +22,50 @@ export default function HeadingInfo() {
       <Collapse isOpen={showInstructions} id="instructions" aria-labelledby="instructions-toggle">
         <div className="info tw-mt-4">
           <p className="tw-mb-4">
-            For conveniently managing your clusters with kubectl, first install the{" "}
+            For managing your clusters with kubectl, install the{" "}
             <a
-              href="https://github.wdf.sap.corp/sap-cloud-infrastructure/persephone"
+              href="https://documentation.global.cloud.sap/docs/customer/containers/persephone/getting-started/installing-scikube/"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Open scikube CLI in a new tab"
+              aria-label="Open scikube installation documentation in a new tab"
               className="tw-text-theme-link hover:tw-underline"
             >
               scikube CLI <Icon size="18" icon="openInNew" className="tw-inline" />
             </a>{" "}
-            utility, then generate the kubeconfig file for your OpenStack domain/project. Download the latest source
-            code zip/tarball, then:
+            utility:
           </p>
 
           <CodeBlock
-            content={`# Generic instructions: all platforms
-PERSEPHONE_VERSION='0.2.0'
-unzip persephone-"$PERSEPHONE_VERSION".zip
-cd persephone-"$PERSEPHONE_VERSION"
-make build/scikube && ./build/scikube -h`}
+            content={`# Install via Homebrew (macOS)
+brew tap sap-cloud-infrastructure/tap
+brew install scikube`}
           />
           <p className="tw-my-4">
-            Make sure to include scikube in your shell PATH. Finally, set up your OpenStack variables and create your
-            "garden kubeconfig" file as follows:
+            Then source your OpenStack credentials and generate a garden kubeconfig:
           </p>
 
           <CodeBlock
             content={`source "<your-openstack-rc-file.sh>"
-# create kubeconfig file
-scikube kubeconfig-for-garden --landscape canary > kubeconfig-for-garden.yaml
-# list your domain/project clusters
+# Create garden kubeconfig
+scikube kubeconfig-for-garden --landscape prod > kubeconfig-for-garden.yaml
+# List clusters in your project
 KUBECONFIG=kubeconfig-for-garden.yaml kubectl get shoot
-# create a new cluster on your domain/project
-KUBECONFIG=kubeconfig-for-garden.yaml kubectl apply -f "<your-new-shoot-manifest.yaml>"`}
+# Connect to a cluster
+KUBECONFIG=kubeconfig-for-garden.yaml scikube kubeconfig-for-shoot --name <cluster-name> > kubeconfig-for-shoot.yaml
+KUBECONFIG=kubeconfig-for-shoot.yaml kubectl get nodes`}
           />
+          <p className="tw-mt-4">
+            For detailed instructions including binary installation and cluster management, see the{" "}
+            <a
+              href="https://documentation.global.cloud.sap/docs/customer/containers/persephone/getting-started/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="tw-text-theme-link hover:tw-underline"
+            >
+              Persephone documentation <Icon size="18" icon="openInNew" className="tw-inline" />
+            </a>
+            .
+          </p>
         </div>
       </Collapse>
     </Card>


### PR DESCRIPTION
## Summary

- Replace outdated build-from-source instructions (hardcoded v0.2.0, `make build/scikube`) with Homebrew install (`brew tap` + `brew install`)
- Add `kubeconfig-for-shoot` step to show the full workflow from install to cluster access
- Link to the new [Persephone documentation](https://documentation.global.cloud.sap/docs/customer/containers/persephone/getting-started/) for detailed instructions
- Use `--landscape prod` as default instead of `canary`

## Context

The Persephone documentation has been written and is available at https://documentation.global.cloud.sap/docs/customer/containers/persephone/. The UI setup instructions should align with the documented install method and link to the docs for full details.

Related: https://github.wdf.sap.corp/cc/documentation-customer/pull/2110

<img width="1189" height="623" alt="Screenshot 2026-06-05 at 16 07 36" src="https://github.com/user-attachments/assets/67d12cf6-6cb1-4353-be8c-d8306b149b64" />



## Test plan

- [ ] Verify the "Show kubectl Setup Instructions" toggle still works
- [ ] Verify the Homebrew commands render correctly in the CodeBlock
- [ ] Verify the documentation links point to valid pages