### PR TITLE
fix(email-service): add plugin_available check for email service navigation

### DIFF
--- a/config/navigations/services_navigation.rb
+++ b/config/navigations/services_navigation.rb
@@ -506,7 +506,7 @@ SimpleNavigation::Configuration.run do |navigation|
                           'Email',
                           -> { plugin('email_service').email_service_path },
                           if: -> {
-                            services.available?(:email_service)
+                            plugin_available?(:email_service) && services.available?(:email_service)
                           },
                           highlights_on: lambda {
                             params[:controller][%r{email_service/?.*}]


### PR DESCRIPTION
## Summary
- Fixed email service navigation item to respect domain_config disabled_plugins setting
- Added missing `plugin_available?(:email_service)` check alongside existing `services.available?(:email_service)` check

## Problem
The email service was appearing in the navigation for domains where it should be disabled (e.g., iaas-... which has `email_service` in its `disabled_plugins` list).

## Root Cause
The navigation item check at `config/navigations/services_navigation.rb:508-510` only checked `services.available?(:email_service)`, which verifies the OpenStack service exists in the catalog, but did not check `plugin_available?(:email_service)`, which respects the `@domain_config.plugin_hidden?` setting.

## Solution
Added the missing `plugin_available?(:email_service)` check to align with:
- The services header check (line 502)
- Other service items (e.g., dns_service, smartops)
- Standard navigation pattern throughout the codebase
