### PR TITLE
fix(kubernetes): fallback to public endpoints for Persephone

### DIFF
--- a/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_service.rb
+++ b/plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_service.rb
@@ -32,13 +32,27 @@ module ServiceLayer
 
       # Cache per landscape to avoid issues when landscape changes
       @elektron_gardener_cache ||= {}
-      @elektron_gardener_cache[gardener_service_name] ||=
-        elektron.service(
+      @elektron_gardener_cache[gardener_service_name] ||= begin
+        # Try internal interface (default) first
+        service = elektron.service(
           gardener_service_name,
-           headers:{
+          headers:{
             "Authorization":"Bearer #{region}:#{elektron.token}"
           }
         )
+        # Verify the internal endpoint is available
+        service.endpoint_url
+        service
+      rescue Elektron::Errors::ServiceEndpointUnavailable
+        # Persephone runs in a different cluster, so fallback to public interface
+        elektron.service(
+          gardener_service_name,
+          interface: "public",
+          headers:{
+            "Authorization":"Bearer #{region}:#{elektron.token}"
+          }
+        )
+      end
     end
 
     private


### PR DESCRIPTION
# Summary

Persephone (the backend for kubernetes_ng plugin) runs in a different cluster than Elektra, making internal endpoints inaccessible. This PR adds a fallback mechanism to use public endpoints when internal endpoints are unavailable, ensuring the kubernetes_ng plugin can communicate with Persephone successfully.

# Changes Made

- Modified `elektron_gardener` method in `plugins/kubernetes_ng/app/services/service_layer/kubernetes_ng_service.rb`
- Added try-rescue block to attempt internal endpoint first (default behavior)
- Falls back to public endpoint if internal endpoint is unavailable
- Added inline comments explaining the Persephone external cluster configuration

# Related Issues

<!-- List any related issues or tickets, including links to them. -->

- N/A

# Screenshots (if applicable)

N/A - Backend service layer change with no visual impact

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings or errors.