### PR TITLE
fix(style): wrong margin for notice box

### DIFF
--- a/app/assets/stylesheets/_aurora_migration.scss
+++ b/app/assets/stylesheets/_aurora_migration.scss
@@ -198,6 +198,7 @@
   width: 100%;
   background: #f4edff;
   box-sizing: border-box;
+  margin-top: 2rem;
 }
 
 .switcher-notice--big {

--- a/app/assets/stylesheets/_aurora_migration.scss
+++ b/app/assets/stylesheets/_aurora_migration.scss
@@ -198,7 +198,7 @@
   width: 100%;
   background: #f4edff;
   box-sizing: border-box;
-  margin-top: 2rem;
+  margin-top: 1rem;
 }
 
 .switcher-notice--big {


### PR DESCRIPTION
# Summary

* tiny change when no subproject is available it looks to narrow 

# Screenshots 

before

<img width="373" height="405" alt="image" src="https://github.com/user-attachments/assets/7a0aab24-6c75-47b1-a512-b00fd92005ab" />

after

<img width="366" height="393" alt="image" src="https://github.com/user-attachments/assets/b63f5e82-a361-4641-9ed6-e23dfe80c1cc" />

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
