### PR TITLE
feat(identity): add PCA roles to allowed roles list for Clavis

### DIFF
--- a/plugins/identity/config/initializers/constants.rb
+++ b/plugins/identity/config/initializers/constants.rb
@@ -23,6 +23,8 @@ ALLOWED_ROLES = %w[
   network_viewer
   objectstore_admin
   objectstore_viewer
+  pca_admin
+  pca_viewer
   role_admin
   role_viewer
   reader


### PR DESCRIPTION
# Summary

With GA we like that users of SCI are able to assign Clavis (PCAaaS) related roles to their users.

# Changes Made

<!-- List the changes that were made in this pull request. -->

added `pca_admin` and `pca_viewer` role
