### PR TITLE
fix(identity): update en.yml to include PCA roles

### DIFF
--- a/plugins/identity/config/locales/en.yml
+++ b/plugins/identity/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
     member: Member
     network_admin: Neutron Administrator
     network_viewer: Neutron Read-Only
+    pca_admin: PCA Administrator
+    pca_viewer: PCA Read-Only
     role_admin: Role Assignments (Authorizations) Administrator
     role_viewer: Role Assignments (Authorizations) Read-Only
     reader: Keystone Read-Only


### PR DESCRIPTION
# Summary

This is a follow for https://github.com/SAP-cloud-infrastructure/elektra/pull/2103, to improve how the roles appear in UI. Whereas currently the roles description appear as this:

> pca_admin (Pca Admin)
> pca_viewer (Pca Viewer)

# Changes Made

- PCA roles descriptions added in `plugins/identity/config/locales/en.yml`

# Related Issues

- Original PR https://github.com/SAP-cloud-infrastructure/elektra/pull/2103

# Checklist

<!-- Ensure that your pull request meets the following requirements. -->

- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings or errors.
