### PR TITLE
chore(core): improve logging for merged domain configs

### DIFF
--- a/config/initializers/domain_config.rb
+++ b/config/initializers/domain_config.rb
@@ -103,11 +103,8 @@ class DomainConfig
       merged_config = merged_config.merge(config)
     end 
     
-    Rails.logger.debug "DomainConfig: Merging configs for #{scoped_domain_name} with #{matching_configs.size} matching domains"
-    # better logging for debugging in development
-    output = StringIO.new # use StringIO to capture output
-    PP.pp(merged_config, output) # pretty print the merged config to the StringIO object
-    Rails.logger.debug "DomainConfig: Merged config:\n#{output.string}"
+    Rails.logger.debug { "DomainConfig: Merging configs for #{scoped_domain_name} with #{matching_configs.size} matching domains" }
+    Rails.logger.debug { "DomainConfig: Merged config:\n#{merged_config.inspect}" }
 
     return merged_config if merged_config.is_a?(Hash)
     raise "DomainConfig: Invalid domain config for #{scoped_domain_name}, expected a Hash, got #{merged_config.class}"


### PR DESCRIPTION
 # Summary

  Fix production crash on landing page caused by missing PP constant in DomainConfig.

 # Changes Made

  - Replace PP.pp(merged_config, output) with merged_config.inspect in DomainConfig#find_config
  - Use block syntax Rails.logger.debug { ... } for lazy evaluation (no-op in production)

#  Related Issues

  Production error after #2120 (sentry removal):
  NameError: uninitialized constant DomainConfig::PP
    config/initializers/domain_config.rb:109:in 'DomainConfig#find_config'

 # Root Cause

  PP (Ruby pretty printer) was used without require 'pp'. it was somehow implicitly loaded as a side-effect? After the sentry removal in #2120 that side-effect disappeared in production, causing every request to crash with a 500.

 # Checklist

  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [x] I have added tests that prove my fix is effective or that my feature works.
  - [x] New and existing unit tests pass locally with my changes.
  - [ ] I have made corresponding changes to the documentation (if applicable).
  - [x] My changes generate no new warnings or errors.
