### PR TITLE
fix(monsoon-openstack-auth): add dashboard domain to allowed CSRF origins

### DIFF
--- a/app/controllers/auth_token_controller.rb
+++ b/app/controllers/auth_token_controller.rb
@@ -76,7 +76,11 @@ class AuthTokenController < ActionController::Base
 
   def allowed_origin?
     # Define your trusted domains
-    trusted_origins = ["https://identity-3.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap"]
+    # Include both identity provider and dashboard domains
+    trusted_origins = [
+      "https://identity-3.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap",
+      "https://dashboard.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap"
+    ]
 
     # Check the Origin header
     origin = request.headers['Origin']


### PR DESCRIPTION
## Problem

Production SSO login was failing with **422 CSRF errors** in `https://dashboard.qa-de-1.cloud.sap/verify-auth-token`.

Error:
```
[33669d80e62405b4cad82bcb7db5a21e] ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.)
```

## Root Cause

The `allowed_origin?` method in `AuthTokenController` only allowed requests from:
- `https://identity-3.{region}.cloud.sap`

But the actual Origin header in production was:
- `https://dashboard.{region}.cloud.sap`

This caused the CSRF check to fail and reject legitimate SSO callback requests.

## Solution

Add the dashboard domain to the list of allowed origins:
```ruby
trusted_origins = [
  "https://identity-3.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap",
  "https://dashboard.#{ENV['MONSOON_DASHBOARD_REGION']}.cloud.sap"
]
```

## Changes

- **File changed:** `app/controllers/auth_token_controller.rb`
- **Lines changed:** 5 insertions, 1 deletion
- **Impact:** Minimal, focused fix

## Testing

- [x] Code review
- [ ] Manual testing in QA environment
- [ ] Verify SSO login works without 422 errors

## Risks

**Risk Level:** LOW ✅

- Minimal change (adds one domain to allowlist)
- Follows existing pattern
- No flow changes
- Easy to revert if needed

## Deployment Notes

This should be deployed to QA first to verify the fix, then to production.